### PR TITLE
feat(chat): source citations and expandable thought process for naive rag

### DIFF
--- a/backend/app/api/v1/endpoints/chat_rag.py
+++ b/backend/app/api/v1/endpoints/chat_rag.py
@@ -219,7 +219,11 @@ async def perform_rag_retrieval(
             {
                 "kb_id": result["kb_id"],
                 "kb_name": result["kb_name"],
-                "document_id": str(result.get("document_id")),
+                "document_id": (
+                    str(result["document_id"])
+                    if result.get("document_id") is not None
+                    else None
+                ),
                 "document_name": result.get("document_name"),
                 "content": result.get("content"),
                 "score": result.get("score"),

--- a/backend/app/api/v1/endpoints/chat_rag.py
+++ b/backend/app/api/v1/endpoints/chat_rag.py
@@ -19,6 +19,7 @@ from app.services.retrieval import (
     retrieve,
     validated_search_mode,
 )
+from app.services.citations import CITATION_MARKER_TEMPLATE, with_rag_citation_ids
 
 if TYPE_CHECKING:
     from app.models.agent import Agent
@@ -213,18 +214,20 @@ async def perform_rag_retrieval(
         )
         return []
 
-    return [
-        {
-            "kb_id": result["kb_id"],
-            "kb_name": result["kb_name"],
-            "document_id": str(result.get("document_id")),
-            "document_name": result.get("document_name"),
-            "content": result.get("content"),
-            "score": result.get("score"),
-            "metadata": result.get("metadata") or {},
-        }
-        for result in response.results
-    ]
+    return with_rag_citation_ids(
+        [
+            {
+                "kb_id": result["kb_id"],
+                "kb_name": result["kb_name"],
+                "document_id": str(result.get("document_id")),
+                "document_name": result.get("document_name"),
+                "content": result.get("content"),
+                "score": result.get("score"),
+                "metadata": result.get("metadata") or {},
+            }
+            for result in response.results
+        ]
+    )
 
 
 def aggregate_rag_contexts(rag_contexts: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -249,6 +252,8 @@ def aggregate_rag_contexts(rag_contexts: list[dict[str, Any]]) -> list[dict[str,
 
         if key in index_map:
             idx = index_map[key]
+            if not aggregated[idx].get("citation_id") and ctx.get("citation_id"):
+                aggregated[idx]["citation_id"] = ctx.get("citation_id")
             if ctx.get("content"):
                 aggregated[idx]["content_parts"].append(ctx.get("content"))
             aggregated[idx]["metadata"].append(ctx.get("metadata") or {})
@@ -270,6 +275,7 @@ def aggregate_rag_contexts(rag_contexts: list[dict[str, Any]]) -> list[dict[str,
                 "kb_name": ctx.get("kb_name"),
                 "document_id": ctx.get("document_id"),
                 "document_name": ctx.get("document_name"),
+                "citation_id": ctx.get("citation_id"),
                 "score": ctx.get("score"),
                 "metadata": [ctx.get("metadata") or {}],
                 "content_parts": [ctx.get("content")] if ctx.get("content") else [],
@@ -280,40 +286,43 @@ def aggregate_rag_contexts(rag_contexts: list[dict[str, Any]]) -> list[dict[str,
         item["content"] = "\n\n".join([p for p in item.get("content_parts", []) if p])
         item.pop("content_parts", None)
 
-    return aggregated
+    return with_rag_citation_ids(aggregated)
 
 
 def build_rag_prompt(rag_contexts: list[dict[str, Any]], user_message: str) -> str:
-    """Build user message with RAG context and citation instructions.
+    """Build user message with RAG context.
 
     Args:
         rag_contexts: List of aggregated retrieval results
         user_message: Original user message
 
     Returns:
-        Enhanced prompt with RAG context and citation format instructions
+        Enhanced prompt with RAG context
     """
     if not rag_contexts:
         return user_message
 
     rag_contexts = aggregate_rag_contexts(rag_contexts)
 
-    # Build numbered references
     references = []
-    for i, ctx in enumerate(rag_contexts, 1):
+    for ctx in rag_contexts:
         references.append(
-            f"[[ref:{i}]] {ctx['kb_name']} - {ctx['document_name']}:\n{ctx['content']}"
+            "\n".join(
+                (
+                    f"citation_id: {ctx['citation_id']}",
+                    f"source: {ctx['kb_name']} - {ctx['document_name']}",
+                    "content:",
+                    ctx["content"],
+                )
+            )
         )
 
     context_text = "\n\n---\n\n".join(references)
 
-    return f"""The following reference materials may help you answer the user's question.
-Use them ONLY if they are relevant to the question.
+    return f"""The following reference materials may help answer the user's question. Use only relevant material.
 
-Citation format requirement:
-- Use ONLY [[cite:N]] where N is the reference number.
-- Do NOT use (ref:N), [ref:N], "ref:N", or any other citation format.
-Only cite sources you actually use. Do not cite if the information comes from your general knowledge.
+If the answer uses a factual statement from a reference, every sentence or list item containing that statement MUST end with the exact source marker `{CITATION_MARKER_TEMPLATE}`, replacing `SOURCE_ID` with that reference's `citation_id`.
+Do not use numeric references such as `[1]` or `[39]`. Never invent, alter, translate, shorten, or renumber a citation ID.
 
 Reference Materials:
 
@@ -321,6 +330,4 @@ Reference Materials:
 
 ---
 
-User question: {user_message}
-
-Remember: Only use [[cite:N]] citations when you actually use information from the references above."""
+User question: {user_message}"""

--- a/backend/app/api/v1/endpoints/chat_tools.py
+++ b/backend/app/api/v1/endpoints/chat_tools.py
@@ -6,6 +6,8 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from app.services.citations import stable_citation_id, with_rag_citation_ids
+
 if TYPE_CHECKING:
     from app.models.agent import Agent
     from app.models.tool import Tool
@@ -140,6 +142,7 @@ async def _execute_asset_tool(
                     "ref": ref,
                     "filename": asset.display_filename,
                     "content": text,
+                    "citation_id": stable_citation_id("asset", asset.id),
                 },
                 ensure_ascii=False,
             )
@@ -160,6 +163,7 @@ async def _execute_asset_tool(
                 "filename": parsed.filename,
                 "content": parsed.content,
                 "truncated": parsed.truncated,
+                "citation_id": stable_citation_id("asset", asset.id),
             },
             ensure_ascii=False,
         )
@@ -247,7 +251,9 @@ async def execute_tool_call(
                 RetrievalRequest(query=query, targets=targets, top_k=top_k)
             )
             return json.dumps(
-                {"contexts": response.results}, ensure_ascii=False, default=str
+                {"contexts": with_rag_citation_ids(response.results)},
+                ensure_ascii=False,
+                default=str,
             )
         except Exception as e:
             logger.exception("RAG search failed: %s", e)

--- a/backend/app/llm/tools/builtin/web_search.py
+++ b/backend/app/llm/tools/builtin/web_search.py
@@ -13,6 +13,7 @@ import httpx
 from markitdown import MarkItDown
 
 from app.core.i18n import t
+from app.services.citations import stable_citation_id, with_web_citation_ids
 from ..registry import tool_registry, ToolParameter
 
 logger = logging.getLogger(__name__)
@@ -101,7 +102,7 @@ async def _tavily_search(
             return {
                 "query": query,
                 "answer": data.get("answer"),
-                "results": results,
+                "results": with_web_citation_ids(results),
                 "success": True,
             }
 
@@ -139,9 +140,16 @@ async def fetch_webpage(url: str, max_length: int = 5000) -> dict:
             asyncio.to_thread(MarkItDown().convert, url), timeout=30
         )
         text = (result.text_content or "").strip()
+        title = (getattr(result, "title", None) or "").strip() or None
         if len(text) > max_length:
             text = text[:max_length] + "..."
-        return {"url": url, "content": text, "success": True}
+        return {
+            "url": url,
+            "title": title,
+            "content": text,
+            "citation_id": stable_citation_id("web", url),
+            "success": True,
+        }
     except Exception as e:
         status_code = getattr(getattr(e, "response", None), "status_code", None)
         if status_code is not None:

--- a/backend/app/services/agent_run_worker.py
+++ b/backend/app/services/agent_run_worker.py
@@ -612,7 +612,10 @@ async def run_agent_round(payload: dict[str, Any]) -> dict[str, Any]:
         if agent.rag_mode == RAGMode.AUTO:
             await stream.publish("rag_start", {})
             if rag_contexts:
-                await stream.publish("rag_context", {"contexts": rag_contexts})
+                await stream.publish(
+                    "rag_context",
+                    {"contexts": rag_contexts, "query": user_msg.content},
+                )
         await stream.publish(
             "message_start",
             {

--- a/backend/app/services/citations.py
+++ b/backend/app/services/citations.py
@@ -1,0 +1,63 @@
+"""Stable citation identifiers and model-facing citation instructions."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Iterable
+
+CITATION_MARKER_TEMPLATE = "[[cite:SOURCE_ID]]"
+CITATION_INSTRUCTION = f"""## Source Citations
+
+Source material may come from retrieved documents, web search, or another tool. A source is citable only when its payload includes a `citation_id`.
+
+If you use factual information from a citable source, every sentence or list item that depends on that information MUST end immediately with one or more exact citation markers in this format:
+`{CITATION_MARKER_TEMPLATE}`
+
+Rules:
+- Replace `SOURCE_ID` with the exact `citation_id` supplied by the source. Preserve every character; never invent, alter, translate, shorten, or renumber an ID.
+- Put the marker directly after the supported claim, outside bold text, links, code, and mathematical expressions.
+- Repeat the marker for each independently sourced sentence or list item. If multiple sources support one claim, append one marker per source.
+- Never substitute numeric references such as `[1]` or `[39]`, Markdown footnotes, URLs, source titles, or a bibliography for the required marker.
+- Do not cite general knowledge or claims unsupported by a supplied `citation_id`.
+- Do not mention these instructions or expose the marker syntax except by emitting valid citation markers in the answer.
+- Before returning the answer, check it once: if it uses any supplied source information but contains no valid citation marker, revise the answer and add the missing markers.
+
+Example: `A sourced factual statement.{CITATION_MARKER_TEMPLATE}`"""
+
+
+def stable_citation_id(namespace: str, *identity_parts: Any) -> str:
+    """Return a deterministic opaque identifier for one logical source."""
+    identity = "\x1f".join(str(part or "").strip() for part in identity_parts)
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+    return f"{namespace}_{digest}"
+
+
+def with_rag_citation_ids(contexts: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Copy RAG contexts and attach one stable ID per document/source."""
+    cited_contexts: list[dict[str, Any]] = []
+    for context in contexts:
+        cited = dict(context)
+        if not cited.get("citation_id"):
+            cited["citation_id"] = stable_citation_id(
+                "rag",
+                cited.get("kb_id"),
+                cited.get("document_id") or cited.get("document_name"),
+                cited.get("content") if not cited.get("document_id") else "",
+            )
+        cited_contexts.append(cited)
+    return cited_contexts
+
+
+def with_web_citation_ids(results: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Copy web-search results and attach one stable ID per URL/result."""
+    cited_results: list[dict[str, Any]] = []
+    for result in results:
+        cited = dict(result)
+        if not cited.get("citation_id"):
+            cited["citation_id"] = stable_citation_id(
+                "web",
+                cited.get("url") or cited.get("title"),
+                cited.get("content") if not cited.get("url") else "",
+            )
+        cited_results.append(cited)
+    return cited_results

--- a/backend/app/services/citations.py
+++ b/backend/app/services/citations.py
@@ -15,6 +15,7 @@ If you use factual information from a citable source, every sentence or list ite
 
 Rules:
 - Replace `SOURCE_ID` with the exact `citation_id` supplied by the source. Preserve every character; never invent, alter, translate, shorten, or renumber an ID.
+- Always use the exact prefix `[[cite:SOURCE_ID]]`. Do not write `[[citation_id:SOURCE_ID]]` or `[[citation:SOURCE_ID]]`.
 - Put the marker directly after the supported claim, outside bold text, links, code, and mathematical expressions.
 - Repeat the marker for each independently sourced sentence or list item. If multiple sources support one claim, append one marker per source.
 - Never substitute numeric references such as `[1]` or `[39]`, Markdown footnotes, URLs, source titles, or a bibliography for the required marker.

--- a/backend/app/services/system_prompt.py
+++ b/backend/app/services/system_prompt.py
@@ -19,6 +19,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
+from app.services.citations import CITATION_INSTRUCTION
+
 if TYPE_CHECKING:
     from app.models.agent import Agent
 
@@ -29,6 +31,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 FILE_CONTENT_PLACEHOLDER = "{{fileContent}}"
+
 
 MARKDOWN_IMAGE_DISPLAY_INSTRUCTION = r"""## Markdown Output
 
@@ -164,7 +167,8 @@ WORKFLOW_MODE = "workflow"
 
 # Sections logged at info when applied (the capability-driven ones); always-on
 # sections (Markdown, language) are silent to match prior noise levels.
-_LOGGED_SECTIONS = frozenset({"memory", "user_input", "sandbox"})
+_LOGGED_SECTIONS = frozenset({"memory", "user_input", "sandbox", "citations"})
+_CITATION_SOURCE_BUILTIN_TOOLS = frozenset({"web_search", "fetch_webpage"})
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +222,23 @@ def has_sandbox_tools(agent: Agent) -> bool:
     return False
 
 
+def has_source_citation_capability(agent: Agent) -> bool:
+    """Return whether chat can supply sources carrying stable citation IDs."""
+    rag_mode = getattr(agent, "rag_mode", "off")
+    rag_mode_value = getattr(rag_mode, "value", rag_mode)
+    if rag_mode_value in {"auto", "agentic"}:
+        return True
+    if bool(getattr(agent, "enable_attachments", False)):
+        return True
+
+    tools_config = getattr(agent, "tools_config", None) or []
+    return any(
+        config.get("type") == "builtin"
+        and config.get("name") in _CITATION_SOURCE_BUILTIN_TOOLS
+        for config in tools_config
+    )
+
+
 def append_prompt_section(base: str, section: str | None) -> str:
     """Append a section to the base prompt with a blank-line separator."""
     normalized_section = (section or "").strip()
@@ -267,6 +288,10 @@ def _sandbox_applies(agent: Agent, _mode: str) -> bool:
     return has_sandbox_tools(agent)
 
 
+def _citations_apply(agent: Agent, mode: str) -> bool:
+    return mode == CHAT_MODE and has_source_citation_capability(agent)
+
+
 def _append_constant(constant: str) -> Callable[[str, Agent, str | None], str]:
     def transform(base: str, _agent: Agent, _locale: str | None) -> str:
         return append_prompt_section(base, constant)
@@ -274,13 +299,18 @@ def _append_constant(constant: str) -> Callable[[str, Agent, str | None], str]:
     return transform
 
 
-# Order matters: Markdown -> Memory -> Sandbox -> User input -> Language.
-# This preserves the historical chat-endpoint ordering exactly.
+# Order matters: Markdown -> Citations -> Memory -> Sandbox -> User input -> Language.
+# Citation guidance precedes capability workflows and remains provider-neutral.
 SECTIONS: tuple[PromptSection, ...] = (
     PromptSection(
         name="markdown",
         applies=_always,
         transform=_append_constant(MARKDOWN_IMAGE_DISPLAY_INSTRUCTION),
+    ),
+    PromptSection(
+        name="citations",
+        applies=_citations_apply,
+        transform=_append_constant(CITATION_INSTRUCTION),
     ),
     PromptSection(
         name="memory",

--- a/backend/tests/api/test_chat_rag_issue255.py
+++ b/backend/tests/api/test_chat_rag_issue255.py
@@ -386,17 +386,19 @@ async def test_perform_rag_retrieval_supports_lexical_only_and_isolates_failures
     assert request.targets[0].embedding_model_id is None
     assert request.targets[1].rerank_model_id == successful_kb.rerank_model_id
     assert request.targets[2].score_threshold == 0.2
-    assert results == [
-        {
-            "kb_id": str(successful_kb.id),
-            "kb_name": "Handbook",
-            "document_id": str(document_id),
-            "document_name": "Guide",
-            "content": "Answer",
-            "score": 0.9,
-            "metadata": {},
-        }
-    ]
+    assert len(results) == 1
+    assert results[0]["citation_id"].startswith("rag_")
+    assert {
+        key: value for key, value in results[0].items() if key != "citation_id"
+    } == {
+        "kb_id": str(successful_kb.id),
+        "kb_name": "Handbook",
+        "document_id": str(document_id),
+        "document_name": "Guide",
+        "content": "Answer",
+        "score": 0.9,
+        "metadata": {},
+    }
 
 
 @pytest.mark.asyncio
@@ -462,7 +464,14 @@ def test_aggregate_rag_contexts_merges_documents_and_keeps_best_numeric_score():
         },
     ]
 
-    assert aggregate_rag_contexts(contexts) == [
+    aggregated = aggregate_rag_contexts(contexts)
+    assert len(aggregated) == 2
+    assert aggregated[0]["citation_id"].startswith("rag_")
+    assert aggregated[1]["citation_id"].startswith("rag_")
+    assert [
+        {key: value for key, value in item.items() if key != "citation_id"}
+        for item in aggregated
+    ] == [
         {
             "kb_id": "kb-1",
             "kb_name": "KB",
@@ -489,32 +498,35 @@ def test_build_rag_prompt_returns_plain_message_without_context():
     assert build_rag_prompt([], "plain question") == "plain question"
 
 
-def test_build_rag_prompt_numbers_aggregated_references():
-    prompt = build_rag_prompt(
-        [
-            {
-                "kb_id": "kb-1",
-                "kb_name": "Policies",
-                "document_id": "doc-1",
-                "document_name": "Leave",
-                "content": "part one",
-                "score": 0.4,
-            },
-            {
-                "kb_id": "kb-1",
-                "kb_name": "Policies",
-                "document_id": "doc-1",
-                "document_name": "Leave",
-                "content": "part two",
-                "score": 0.7,
-            },
-        ],
-        "How much leave?",
-    )
+def test_build_rag_prompt_uses_stable_aggregated_source_ids():
+    contexts = [
+        {
+            "kb_id": "kb-1",
+            "kb_name": "Policies",
+            "document_id": "doc-1",
+            "document_name": "Leave",
+            "content": "part one",
+            "score": 0.4,
+        },
+        {
+            "kb_id": "kb-1",
+            "kb_name": "Policies",
+            "document_id": "doc-1",
+            "document_name": "Leave",
+            "content": "part two",
+            "score": 0.7,
+        },
+    ]
+    aggregated = aggregate_rag_contexts(contexts)
+    prompt = build_rag_prompt(contexts, "How much leave?")
 
-    assert "[[ref:1]] Policies - Leave:\npart one\n\npart two" in prompt
-    assert "[[ref:2]]" not in prompt
-    assert "Use ONLY [[cite:N]]" in prompt
+    assert len(aggregated) == 1
+    citation_id = aggregated[0]["citation_id"]
+    assert citation_id.startswith("rag_")
+    assert f"citation_id: {citation_id}" in prompt
+    assert "source: Policies - Leave\ncontent:\npart one\n\npart two" in prompt
+    assert "[[cite:SOURCE_ID]]" in prompt
+    assert "Do not use numeric references such as `[1]` or `[39]`" in prompt
     assert "User question: How much leave?" in prompt
 
 

--- a/backend/tests/llm/test_web_search_issue255.py
+++ b/backend/tests/llm/test_web_search_issue255.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from app.llm.tools.builtin import web_search as subject
+from app.services.citations import stable_citation_id
 
 
 class FakeClient:
@@ -42,12 +43,14 @@ def http_error(status_code=503):
     return httpx.HTTPStatusError("rejected", request=request, response=response)
 
 
-def install_markitdown(monkeypatch, *, text_content="", exc=None):
+def install_markitdown(monkeypatch, *, text_content="", title=None, exc=None):
     converter = MagicMock()
     if exc is not None:
         converter.convert.side_effect = exc
     else:
-        converter.convert.return_value = SimpleNamespace(text_content=text_content)
+        converter.convert.return_value = SimpleNamespace(
+            text_content=text_content, title=title
+        )
     monkeypatch.setattr(subject, "MarkItDown", lambda: converter)
     return converter
 
@@ -125,20 +128,22 @@ async def test_tavily_posts_expected_payload_and_normalizes_results(monkeypatch)
         },
     )
     response.raise_for_status.assert_called_once_with()
-    assert result == {
-        "query": "cloud security",
-        "answer": "A concise answer",
-        "results": [
-            {
-                "title": "Result",
-                "url": "https://example.test/page",
-                "content": "Excerpt",
-                "score": 0.9,
-            },
-            {"title": "", "url": "", "content": "", "score": None},
-        ],
-        "success": True,
-    }
+    assert result["query"] == "cloud security"
+    assert result["answer"] == "A concise answer"
+    assert result["success"] is True
+    assert all(item["citation_id"].startswith("web_") for item in result["results"])
+    assert [
+        {key: value for key, value in item.items() if key != "citation_id"}
+        for item in result["results"]
+    ] == [
+        {
+            "title": "Result",
+            "url": "https://example.test/page",
+            "content": "Excerpt",
+            "score": 0.9,
+        },
+        {"title": "", "url": "", "content": "", "score": None},
+    ]
 
 
 @pytest.mark.anyio
@@ -171,14 +176,18 @@ async def test_tavily_maps_provider_failures(monkeypatch, failure, expected_erro
 
 @pytest.mark.anyio
 async def test_fetch_webpage_converts_url_via_markitdown_and_truncates(monkeypatch):
-    converter = install_markitdown(monkeypatch, text_content="x" * 100)
+    converter = install_markitdown(
+        monkeypatch, text_content="x" * 100, title="  Page Title  "
+    )
 
     result = await subject.fetch_webpage("https://example.test/page", 10)
 
     converter.convert.assert_called_once_with("https://example.test/page")
     assert result == {
         "url": "https://example.test/page",
+        "title": "Page Title",
         "content": "xxxxxxxxxx...",
+        "citation_id": stable_citation_id("web", "https://example.test/page"),
         "success": True,
     }
 

--- a/backend/tests/services/test_asset_tools.py
+++ b/backend/tests/services/test_asset_tools.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import pytest
 
 from app.api.v1.endpoints.chat_tools import _execute_asset_tool
+from app.services.citations import stable_citation_id
 from app.schemas.response import BusinessError
 
 
@@ -144,6 +145,7 @@ async def test_read_asset_returns_text():
     data = json.loads(result)
     assert data["content"] == "hello world"
     assert data["ref"] == "abcd"
+    assert data["citation_id"] == stable_citation_id("asset", asset.id)
 
 
 @pytest.mark.asyncio
@@ -210,6 +212,7 @@ async def test_parse_asset_returns_parsed_content():
     data = json.loads(result)
     assert data["content"] == "parsed content"
     assert "truncated" in data
+    assert data["citation_id"] == stable_citation_id("asset", asset.id)
     parse_config = parse_file.await_args.args[2]
     assert parse_config.max_content_length == 1234
     assert parse_config.truncate_strategy == "middle"

--- a/backend/tests/services/test_chat_context_sandbox_prompt.py
+++ b/backend/tests/services/test_chat_context_sandbox_prompt.py
@@ -3,12 +3,13 @@ from types import SimpleNamespace
 from app.services.chat_context import _build_system_prompt
 
 
-def _agent(*, tools_config=None, system_prompt="Base prompt"):
+def _agent(*, tools_config=None, system_prompt="Base prompt", rag_mode=None):
     return SimpleNamespace(
         id="agent-1",
         system_prompt=system_prompt,
         enable_memory=False,
         tools_config=tools_config or [],
+        rag_mode=rag_mode,
     )
 
 
@@ -64,6 +65,20 @@ def test_build_system_prompt_skips_sandbox_guidance_without_sandbox_tools():
 
     assert "## Sandbox Environment Guidance" not in prompt
     assert "Base prompt" in prompt
+
+
+def test_build_system_prompt_injects_source_citation_contract_for_rag_chat():
+    prompt = _build_system_prompt(
+        agent=_agent(rag_mode="auto"),
+        conversation=_conversation(),
+        user_message="answer from the knowledge base",
+        user_locale="en",
+    )
+
+    assert "## Source Citations" in prompt
+    assert "[[cite:SOURCE_ID]]" in prompt
+    assert "every sentence or list item" in prompt
+    assert "Never substitute numeric references" in prompt
 
 
 def test_build_system_prompt_formats_sections_with_clear_spacing():

--- a/backend/tests/services/test_chat_tools_branches_issue255.py
+++ b/backend/tests/services/test_chat_tools_branches_issue255.py
@@ -115,7 +115,8 @@ async def test_knowledge_search_aggregates_results_and_handles_provider_error():
             agent=SimpleNamespace(id="agent-1"),
         )
 
-    assert json.loads(result) == {
+    payload = json.loads(result)
+    assert payload == {
         "contexts": [
             {
                 "kb_id": "kb-1",
@@ -124,9 +125,11 @@ async def test_knowledge_search_aggregates_results_and_handles_provider_error():
                 "document_name": "Guide",
                 "content": "Answer",
                 "score": 0.9,
+                "citation_id": payload["contexts"][0]["citation_id"],
             }
         ]
     }
+    assert payload["contexts"][0]["citation_id"].startswith("rag_")
     request = retrieve.await_args.args[0]
     assert request.query == "policy"
     assert request.top_k == 2

--- a/backend/tests/services/test_system_prompt_manager.py
+++ b/backend/tests/services/test_system_prompt_manager.py
@@ -20,12 +20,16 @@ def _agent(
     system_prompt="Base prompt",
     enable_memory=False,
     enable_user_input_request=False,
+    enable_attachments=False,
+    rag_mode="off",
 ):
     return SimpleNamespace(
         id="agent-1",
         system_prompt=system_prompt,
         enable_memory=enable_memory,
         enable_user_input_request=enable_user_input_request,
+        enable_attachments=enable_attachments,
+        rag_mode=rag_mode,
         tools_config=tools_config or [],
     )
 
@@ -103,6 +107,48 @@ def test_chat_mode_injects_ask_user_guidance_when_enabled():
     )
     assert "## User Input Requests" in prompt
     assert "call `ask_user`" in prompt
+
+
+@pytest.mark.parametrize(
+    "agent",
+    [
+        _agent(rag_mode="auto"),
+        _agent(rag_mode="agentic"),
+        _agent(tools_config=[{"type": "builtin", "name": "web_search"}]),
+        _agent(tools_config=[{"type": "builtin", "name": "fetch_webpage"}]),
+        _agent(enable_attachments=True),
+    ],
+)
+def test_chat_mode_injects_source_citation_contract_for_source_capabilities(agent):
+    prompt = build_system_prompt(agent, invocation_mode=CHAT_MODE)
+
+    assert "## Source Citations" in prompt
+    assert "[[cite:SOURCE_ID]]" in prompt
+    assert "Never substitute numeric references" in prompt
+    assert "if it uses any supplied source information" in prompt
+
+
+@pytest.mark.parametrize(
+    "agent",
+    [
+        _agent(),
+        _agent(tools_config=[{"type": "builtin", "name": "generate_image"}]),
+        _agent(tools_config=[{"type": "custom", "tool_id": "weather-tool"}]),
+    ],
+)
+def test_chat_mode_skips_source_citation_contract_without_source_capabilities(agent):
+    prompt = build_system_prompt(agent, invocation_mode=CHAT_MODE)
+
+    assert "## Source Citations" not in prompt
+
+
+def test_workflow_mode_skips_source_citation_contract():
+    prompt = build_system_prompt(
+        _agent(rag_mode="auto", enable_attachments=True),
+        invocation_mode=WORKFLOW_MODE,
+    )
+
+    assert "## Source Citations" not in prompt
 
 
 def test_ask_user_guidance_requires_the_chat_tool_injection_path():

--- a/frontend/app/(chat)/chat/[id]/page.test.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.test.tsx
@@ -344,7 +344,29 @@ describe('PublicChatPage', () => {
     await flush()
 
     expect(getRunStatus).toHaveBeenCalledWith('agent-1', 'run-1')
-    expect(renderer!.root.findAllByType('i').filter((node) => node.props.className === 'h-4 w-4 shrink-0 animate-spin text-muted-foreground')).toHaveLength(1)
+    expect(renderer!.root.findAllByType('i').filter((node) => node.props.className?.includes('animate-spin') && node.props.className?.includes('group-hover:opacity-0'))).toHaveLength(1)
+  })
+
+  test('renders running indicator overlapping dropdown actions slot with hover swapping classes', async () => {
+    getStoredRunSnapshot.mockImplementation((agentId: string, conversationId: string) => (
+      agentId === 'agent-1' && conversationId === 'conv-1' ? { runId: 'run-1', lastSequence: 0 } : null
+    ))
+    getRunStatus.mockResolvedValue({ status: 'running' })
+
+    render()
+    await flush()
+
+    const loader = renderer!.root.findAllByType('i').find((node) => node.props.className?.includes('group-hover:opacity-0'))
+    expect(loader).toBeDefined()
+    expect(loader!.props['aria-label']).toBe('loading')
+
+    const dropdownTriggers = renderer!.root.findAllByType('button').filter((node) => {
+      const className = node.props.className
+      return typeof className === 'string' && className.includes('absolute inset-0')
+    })
+    expect(dropdownTriggers).toHaveLength(2)
+    expect(dropdownTriggers[0].props.className).toContain('opacity-0 group-hover:opacity-100')
+    expect(dropdownTriggers[0].props.className).toContain('focus-visible:opacity-100')
   })
 
   test('removes stored snapshot for completed background conversation', async () => {
@@ -383,7 +405,7 @@ describe('PublicChatPage', () => {
       await Promise.resolve()
     })
     expect(getRunStatus).toHaveBeenCalledWith('agent-1', 'replacement-run')
-    expect(renderer!.root.findAllByType('i').filter((node) => node.props.className === 'h-4 w-4 shrink-0 animate-spin text-muted-foreground')).toHaveLength(1)
+    expect(renderer!.root.findAllByType('i').filter((node) => node.props.className?.includes('animate-spin') && node.props.className?.includes('group-hover:opacity-0'))).toHaveLength(1)
 
     await act(async () => {
       resolveOldStatus({ status: 'completed' })
@@ -391,7 +413,7 @@ describe('PublicChatPage', () => {
     })
 
     expect(removeRunSnapshot).not.toHaveBeenCalled()
-    expect(renderer!.root.findAllByType('i').filter((node) => node.props.className === 'h-4 w-4 shrink-0 animate-spin text-muted-foreground')).toHaveLength(1)
+    expect(renderer!.root.findAllByType('i').filter((node) => node.props.className?.includes('animate-spin') && node.props.className?.includes('group-hover:opacity-0'))).toHaveLength(1)
   })
   test('places pending ask_user above the composer and forwards final answers', async () => {
     const submitAskUser = mock(async () => undefined)

--- a/frontend/app/(chat)/chat/[id]/page.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.tsx
@@ -944,7 +944,7 @@ export default function PublicChatPage({
                               "absolute inset-0 flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
                               runningConversationIds.has(conv.id)
                                 ? "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                                : "opacity-0 group-hover:opacity-100"
+                                : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
                             )}
                           >
                             <span className="flex h-7 w-7 items-center justify-center">

--- a/frontend/app/(chat)/chat/[id]/page.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.tsx
@@ -930,33 +930,44 @@ export default function PublicChatPage({
                       <p className="flex-1 text-sm text-foreground truncate">
                         {conv.title || t('untitledChat')}
                       </p>
-                      {runningConversationIds.has(conv.id) && (
-                        <Loader2 aria-label={tCommon('loading')} className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
-                      )}
-                      <DropdownMenu>
-                        <DropdownMenuTrigger onClick={(e) => e.stopPropagation()}>
-                          <span
-                            className="h-7 w-7 opacity-0 group-hover:opacity-100 flex items-center justify-center rounded-md hover:bg-accent transition-colors"
+                      <div className="relative flex h-7 w-7 shrink-0 items-center justify-center">
+                        {runningConversationIds.has(conv.id) && (
+                          <Loader2
+                            aria-label={tCommon('loading')}
+                            className="h-4 w-4 shrink-0 animate-spin text-muted-foreground transition-opacity group-hover:opacity-0"
+                          />
+                        )}
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            onClick={(e) => e.stopPropagation()}
+                            className={cn(
+                              "absolute inset-0 flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                              runningConversationIds.has(conv.id)
+                                ? "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                                : "opacity-0 group-hover:opacity-100"
+                            )}
                           >
-                            <MoreHorizontal className="h-4 w-4" />
-                          </span>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            onClick={(e) => handleRenameClick(conv, e as unknown as React.MouseEvent)}
-                          >
-                            <Pencil className="h-4 w-4 mr-2" />
-                            {t('rename')}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            variant="destructive"
-                            onClick={(e) => handleDeleteClick(conv, e as unknown as React.MouseEvent)}
-                          >
-                            <Trash2 className="h-4 w-4 mr-2" />
-                            {t('delete')}
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                            <span className="flex h-7 w-7 items-center justify-center">
+                              <MoreHorizontal className="h-4 w-4" />
+                            </span>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={(e) => handleRenameClick(conv, e as unknown as React.MouseEvent)}
+                            >
+                              <Pencil className="mr-2 h-4 w-4" />
+                              {t('rename')}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              variant="destructive"
+                              onClick={(e) => handleDeleteClick(conv, e as unknown as React.MouseEvent)}
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" />
+                              {t('delete')}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
                     </div>
                   ))}
                   {/* Sentinel element for infinite scroll */}

--- a/frontend/components/ai-elements/chain-of-thought-issue255.test.tsx
+++ b/frontend/components/ai-elements/chain-of-thought-issue255.test.tsx
@@ -50,6 +50,23 @@ describe('chain of thought AI element', () => {
     expect(changes).toEqual([true])
   })
 
+  test('keeps the expand toggle next to the Chain of Thought title', () => {
+    const renderer = render(
+      <ChainOfThought defaultOpen={false}>
+        <ChainOfThoughtHeader title="Reasoning" />
+      </ChainOfThought>,
+    )
+    const header = renderer.root.findByType('button')
+    const headerMarkup = JSON.stringify(renderer.toJSON())
+
+    expect(header.props.className).toContain('group')
+    expect(header.props.className).toContain('gap-2')
+    expect(headerMarkup).not.toContain('ml-auto')
+    expect(headerMarkup).toContain('opacity-0')
+    expect(headerMarkup).toContain('group-hover:opacity-100')
+    expect(headerMarkup).toContain('focus-visible:opacity-100')
+  })
+
   test('auto-closes once after streaming ends', () => {
     jest.useFakeTimers()
     const changes: boolean[] = []

--- a/frontend/components/ai-elements/chain-of-thought-issue255.test.tsx
+++ b/frontend/components/ai-elements/chain-of-thought-issue255.test.tsx
@@ -64,7 +64,7 @@ describe('chain of thought AI element', () => {
     expect(headerMarkup).not.toContain('ml-auto')
     expect(headerMarkup).toContain('opacity-0')
     expect(headerMarkup).toContain('group-hover:opacity-100')
-    expect(headerMarkup).toContain('focus-visible:opacity-100')
+    expect(headerMarkup).toContain('group-focus-visible:opacity-100')
   })
 
   test('auto-closes once after streaming ends', () => {

--- a/frontend/components/ai-elements/chain-of-thought.tsx
+++ b/frontend/components/ai-elements/chain-of-thought.tsx
@@ -132,7 +132,7 @@ export const ChainOfThoughtHeader = memo(
         )}
         <ChevronDownIcon
           className={cn(
-            "size-4 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100",
+            "size-4 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100",
             isOpen ? "rotate-180" : "rotate-0"
           )}
         />

--- a/frontend/components/ai-elements/chain-of-thought.tsx
+++ b/frontend/components/ai-elements/chain-of-thought.tsx
@@ -114,7 +114,7 @@ export const ChainOfThoughtHeader = memo(
       <button
         type="button"
         className={cn(
-          "flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground",
+          "group flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground",
           className
         )}
         onClick={() => setIsOpen(!isOpen)}
@@ -132,7 +132,7 @@ export const ChainOfThoughtHeader = memo(
         )}
         <ChevronDownIcon
           className={cn(
-            "size-4 ml-auto transition-transform",
+            "size-4 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100",
             isOpen ? "rotate-180" : "rotate-0"
           )}
         />

--- a/frontend/components/ai-elements/inline-citation.tsx
+++ b/frontend/components/ai-elements/inline-citation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   Carousel,
@@ -13,9 +14,9 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { cn } from "@/lib/utils";
-import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import {
   type ComponentProps,
+  type ReactNode,
   createContext,
   useCallback,
   useContext,
@@ -55,22 +56,32 @@ export const InlineCitationCard = (props: InlineCitationCardProps) => (
 
 export type InlineCitationCardTriggerProps = ComponentProps<typeof Badge> & {
   sources: string[];
+  label?: ReactNode;
 };
 
 export const InlineCitationCardTrigger = ({
   sources,
+  label,
   className,
   ...props
-}: InlineCitationCardTriggerProps) => (
-  <HoverCardTrigger render={<Badge className={cn("ml-1 rounded-full", className)} variant="secondary" {...props} />}>{sources[0] ? (
-            <>
-              {new URL(sources[0]).hostname}{" "}
-              {sources.length > 1 && `+${sources.length - 1}`}
-            </>
-          ) : (
-            "unknown"
-          )}</HoverCardTrigger>
-);
+}: InlineCitationCardTriggerProps) => {
+  let hostname = "unknown";
+  if (sources[0]) {
+    try {
+      hostname = new URL(sources[0]).hostname;
+    } catch {
+      hostname = sources[0];
+    }
+  }
+
+  return (
+    <HoverCardTrigger
+      render={<Badge className={cn("ml-1 rounded-full", className)} variant="secondary" {...props} />}
+    >
+      {label ?? (sources.length > 1 ? `${hostname} +${sources.length - 1}` : hostname)}
+    </HoverCardTrigger>
+  );
+};
 
 export type InlineCitationCardBodyProps = ComponentProps<"div">;
 
@@ -78,7 +89,13 @@ export const InlineCitationCardBody = ({
   className,
   ...props
 }: InlineCitationCardBodyProps) => (
-  <HoverCardContent className={cn("relative w-80 p-0", className)} {...props} />
+  <HoverCardContent
+    className={cn(
+      "relative w-[min(calc(100vw-2rem),24rem)] max-h-80 overflow-y-auto overflow-x-hidden p-0 break-words [scrollbar-width:thin]",
+      className
+    )}
+    {...props}
+  />
 );
 
 const CarouselApiContext = createContext<CarouselApi | undefined>(undefined);
@@ -205,7 +222,7 @@ export const InlineCitationCarouselPrev = ({
       type="button"
       {...props}
     >
-      <ArrowLeftIcon className="size-4 text-muted-foreground" />
+      <ChevronLeft className="size-4 text-muted-foreground" />
     </button>
   );
 };
@@ -232,7 +249,7 @@ export const InlineCitationCarouselNext = ({
       type="button"
       {...props}
     >
-      <ArrowRightIcon className="size-4 text-muted-foreground" />
+      <ChevronRight className="size-4 text-muted-foreground" />
     </button>
   );
 };
@@ -276,7 +293,7 @@ export const InlineCitationQuote = ({
 }: InlineCitationQuoteProps) => (
   <blockquote
     className={cn(
-      "border-muted border-l-2 pl-3 text-muted-foreground text-sm italic",
+      "border-muted border-l-2 pl-3 text-muted-foreground text-xs leading-relaxed line-clamp-6 break-words whitespace-pre-wrap",
       className
     )}
     {...props}

--- a/frontend/components/chat/message-parts/message-parts.test.tsx
+++ b/frontend/components/chat/message-parts/message-parts.test.tsx
@@ -72,28 +72,17 @@ function click(element: Element) {
 }
 
 describe('chat message part renderers', () => {
-  it('renders normalized citations, invokes their callback, and shows the streaming cursor', () => {
-    const onCitationClick = mock(() => {})
+  it('renders text content directly and shows the streaming cursor', () => {
     const container = render(
       <TextContent
         part={{ type: 'text', text: 'See [ref:1] and (ref:2).', state: 'streaming' }}
-        sources={[
-          { type: 'source-document', documentName: 'Guide', content: 'one' },
-          { type: 'source-document', documentName: 'FAQ', content: 'two' },
-        ]}
-        onCitationClick={onCitationClick}
       />
     )
 
-    const badges = container.querySelectorAll('button')
-    expect(Array.from(badges, (badge) => badge.textContent)).toEqual(['1', '2'])
-    expect(badges[0].getAttribute('aria-label')).toBe('Guide')
+    expect(container.textContent).toContain('See [ref:1] and (ref:2).')
+    expect(container.querySelectorAll('button')).toHaveLength(0)
     expect(container.querySelector('.animate-blink')).not.toBeNull()
-
-    click(badges[1])
-    expect(onCitationClick).toHaveBeenCalledWith(2)
   })
-
   it('shows streaming reasoning, then lets completed reasoning collapse after displaying duration', () => {
     const container = render(
       <ReasoningContent

--- a/frontend/components/chat/message-parts/source-content.test.tsx
+++ b/frontend/components/chat/message-parts/source-content.test.tsx
@@ -131,6 +131,26 @@ describe("SourceContent", () => {
     ).toBeDefined();
   });
 
+  test("displays page title when available and falls back to hostname when missing or whitespace", () => {
+    const sources = [
+      { type: "source-url" as const, url: "https://example.com/page1", title: "Documentation Guide" },
+      { type: "source-url" as const, url: "https://sub.example.com/page2", title: "   " },
+      { type: "source-url" as const, url: "https://blog.example.com/page3" },
+    ];
+    const tree = render(sources);
+    find(tree, (node) => node.props["aria-expanded"] === false).props.onClick();
+    const expanded = render(sources);
+    const links = [
+      find(expanded, (node) => node.type === "a" && node.props.href === "https://example.com/page1"),
+      find(expanded, (node) => node.type === "a" && node.props.href === "https://sub.example.com/page2"),
+      find(expanded, (node) => node.type === "a" && node.props.href === "https://blog.example.com/page3"),
+    ];
+
+    expect(find(links[0], (node) => node.type === "span").props.children).toBe("Documentation Guide");
+    expect(find(links[1], (node) => node.type === "span").props.children).toBe("sub.example.com");
+    expect(find(links[2], (node) => node.type === "span").props.children).toBe("blog.example.com");
+  });
+
   test("opens preview with document segments when a document is selected", () => {
     const onOpenCodePreview = mock(() => {});
     const sources = Array.from({ length: 6 }, (_, index) => ({

--- a/frontend/components/chat/message-parts/source-content.tsx
+++ b/frontend/components/chat/message-parts/source-content.tsx
@@ -184,7 +184,7 @@ export const SourceContent = memo(function SourceContent({ sources, onOpenCodePr
 });
 
 function getUrlDisplayText(source: SourceUrlPart, fallback: string) {
-  if (source.title) return source.title;
+  if (source.title?.trim()) return source.title.trim();
 
   try {
     return new URL(source.url).hostname;

--- a/frontend/components/chat/message-parts/text-content.test.tsx
+++ b/frontend/components/chat/message-parts/text-content.test.tsx
@@ -41,72 +41,31 @@ mock.module("@/components/ui/tooltip", () => ({
   TooltipContent: (props: Record<string, unknown>) => jsx("tooltip-content", props),
 }));
 
-const { TextContent } = await import("./text-content");
+const { TextContent, TextContentComponent } = await import("./text-content");
+const RenderTextContent = (TextContentComponent || (typeof TextContent === 'function' ? TextContent : (TextContent as unknown as { type: (props: unknown) => unknown }).type)) as unknown as typeof TextContent;
 
-type Tree = { type: unknown; props: Record<string, unknown> };
-
-function resolve(node: ReactNode): Tree | ReactNode {
-  if (!node || typeof node !== "object" || !("type" in node)) return node;
-  const tree = node as Tree;
-  return typeof tree.type === "function"
-    ? resolve(
-        (tree.type as (props: Record<string, unknown>) => ReactNode)(
-          tree.props,
-        ),
-      )
-    : tree;
-}
 
 function streamdownProps(
   part: React.ComponentProps<typeof TextContent>["part"],
 ) {
-  const tree = TextContent({ part }) as Tree;
+  const tree = RenderTextContent({ part }) as Tree;
   return (tree.props.children as Tree[])[0].props;
 }
 
 describe("TextContent", () => {
-  test("normalizes citation formats before sending markdown to Streamdown", () => {
+  test("passes raw markdown directly to Streamdown without citation replacement", () => {
     const props = streamdownProps({
       type: "text",
       text: "One [[ref:1]], [ref:2], (ref:3), and [[cite:4]].",
     });
 
     expect(props.children).toBe(
-      "One <cite-1>, <cite-2>, <cite-3>, and <cite-4>.",
+      "One [[ref:1]], [ref:2], (ref:3), and [[cite:4]].",
     );
   });
 
-  test("renders citation badges with source metadata and forwards clicks", () => {
-    const clicked: number[] = [];
-    const tree = TextContent({
-      part: { type: "text", text: "Answer [[cite:1]]" },
-      sources: [
-        { type: "source-document", documentName: "Guide", content: "Source" },
-      ],
-      onCitationClick: (index) => clicked.push(index),
-    }) as Tree;
-    const streamdown = (tree.props.children as Tree[])[0];
-    const paragraph = streamdown.props.components.p as (
-      props: Record<string, unknown>,
-    ) => ReactNode;
-    const rendered = paragraph({
-      children: "Answer <cite-1>",
-      node: { children: [] },
-    }) as Tree;
-    const fragment = resolve(rendered.props.children) as Tree;
-    const tooltip = resolve((fragment.props.children as ReactNode[])[1]) as Tree;
-    const badge = resolve((tooltip.props.children as ReactNode[])[0]) as Tree;
-
-    expect(badge).toMatchObject({
-      type: "button",
-      props: { "aria-label": "Guide", children: 1 },
-    });
-    badge.props.onClick();
-    expect(clicked).toEqual([1]);
-  });
-
   test("uses block paragraphs for image nodes and shows the streaming cursor", () => {
-    const tree = TextContent({
+    const tree = RenderTextContent({
       part: { type: "text", text: "![image](url)", state: "streaming" },
     }) as Tree;
     const children = tree.props.children as Tree[];

--- a/frontend/components/chat/message-parts/text-content.test.tsx
+++ b/frontend/components/chat/message-parts/text-content.test.tsx
@@ -44,6 +44,7 @@ mock.module("@/components/ui/tooltip", () => ({
 const { TextContent, TextContentComponent } = await import("./text-content");
 const RenderTextContent = (TextContentComponent || (typeof TextContent === 'function' ? TextContent : (TextContent as unknown as { type: (props: unknown) => unknown }).type)) as unknown as typeof TextContent;
 
+type Tree = { type: unknown; props: Record<string, unknown> };
 
 function streamdownProps(
   part: React.ComponentProps<typeof TextContent>["part"],

--- a/frontend/components/chat/message-parts/text-content.tsx
+++ b/frontend/components/chat/message-parts/text-content.tsx
@@ -2,92 +2,17 @@
 
 import * as React from 'react'
 import { memo } from 'react'
-import { useTranslations } from 'next-intl'
 import { Streamdown } from 'streamdown'
 import { cn } from '@/lib/utils'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import type { TextPart, SourceDocumentPart } from '../types'
+import type { TextPart } from '../types'
 
 export interface TextContentProps {
   part: TextPart
   className?: string
-  /** RAG sources for citation rendering */
-  sources?: SourceDocumentPart[]
-  /** Callback when citation is clicked */
-  onCitationClick?: (sourceIndex: number) => void
 }
 
-// Parse text and replace citations [[cite:N]] with placeholder
-function processCitations(
-  text: string,
-  sources?: SourceDocumentPart[]
-): { processedText: string; citations: Map<string, { index: number; source?: SourceDocumentPart }> } {
-  const citations = new Map<string, { index: number; source?: SourceDocumentPart }>()
-  const normalized = text
-    .replace(/\[\[ref:(\d+)\]\]/gi, '[[cite:$1]]')
-    .replace(/\[ref:(\d+)\]/gi, '[[cite:$1]]')
-    .replace(/\(ref:(\d+)\)/gi, '[[cite:$1]]')
-  const regex = /\[\[cite:(\d+)\]\]/g
-  
-  const processedText = normalized.replace(regex, (match, num) => {
-    const index = parseInt(num, 10)
-    const placeholder = `<cite-${index}>`
-    citations.set(placeholder, { index, source: sources?.[index - 1] })
-    return placeholder
-  })
-  
-  return { processedText, citations }
-}
-
-export const TextContent = memo(
-  ({ part, className, sources, onCitationClick }: TextContentProps) => {
-    const isStreaming = part.state === 'streaming'
-    
-    // Process citations
-    const { processedText } = React.useMemo(
-      () => processCitations(part.text, sources),
-      [part.text, sources]
-    )
-
-    // Custom component to render citations
-    const CitationRenderer = React.useCallback(
-      ({ children }: { children?: React.ReactNode }) => {
-        const text = String(children || '')
-        // Check if this text contains our citation placeholders
-        const parts: React.ReactNode[] = []
-        let lastIndex = 0
-        const citationRegex = /<cite-(\d+)>/g
-        let match
-
-        while ((match = citationRegex.exec(text)) !== null) {
-          // Add text before citation
-          if (match.index > lastIndex) {
-            parts.push(text.slice(lastIndex, match.index))
-          }
-          // Add citation badge
-          const index = parseInt(match[1], 10)
-          const source = sources?.[index - 1]
-          parts.push(
-            <CitationBadge
-              key={`cite-${index}-${match.index}`}
-              index={index}
-              source={source}
-              onClick={() => onCitationClick?.(index)}
-            />
-          )
-          lastIndex = citationRegex.lastIndex
-        }
-
-        // Add remaining text
-        if (lastIndex < text.length) {
-          parts.push(text.slice(lastIndex))
-        }
-
-        return parts.length > 0 ? <>{parts}</> : <>{children}</>
-      },
-      [sources, onCitationClick]
-    )
-
+export function TextContentComponent({ part, className }: TextContentProps) {
+  const isStreaming = part.state === 'streaming'
     return (
       <div
         className={cn(
@@ -97,7 +22,6 @@ export const TextContent = memo(
       >
         <Streamdown
           components={{
-            // Override text rendering to handle citations
             // Use div instead of p when paragraph contains block elements (like images)
             // This prevents React hydration error: <div> cannot be a descendant of <p>
             p: ({ children, node, ...props }) => {
@@ -112,66 +36,36 @@ export const TextContent = memo(
                   (child.type === 'div' || child.type === 'img' || typeof child.type === 'function')
               )
               if (hasImgInNode || hasBlockElements) {
-                return <div className="my-4" {...props}><CitationRenderer>{children}</CitationRenderer></div>
+                return <div className="my-4" {...props}>{children}</div>
               }
               return (
                 <p {...props}>
-                  <CitationRenderer>{children}</CitationRenderer>
+                  {children}
                 </p>
               )
             },
             li: ({ children, ...props }) => (
               <li {...props}>
-                <CitationRenderer>{children}</CitationRenderer>
+                {children}
               </li>
             ),
           }}
         >
-          {processedText}
+          {part.text}
         </Streamdown>
         {isStreaming && (
           <span className="inline-block w-0.5 h-4 ml-0.5 bg-current animate-blink align-text-bottom" />
         )}
       </div>
     )
-  },
+}
+
+export const TextContent = memo(
+  TextContentComponent,
   (prevProps, nextProps) =>
     prevProps.part.text === nextProps.part.text &&
-    prevProps.part.state === nextProps.part.state &&
-    prevProps.sources === nextProps.sources
+    prevProps.part.state === nextProps.part.state
 )
 
 TextContent.displayName = 'TextContent'
 
-interface CitationBadgeProps {
-  index: number
-  source?: SourceDocumentPart
-  onClick?: () => void
-}
-
-function CitationBadge({ index, source, onClick }: CitationBadgeProps) {
-  const t = useTranslations('chat.source')
-  const title = source?.documentName || t('documentDefault')
-
-  return (
-    <Tooltip>
-      <TooltipTrigger
-        type="button"
-        onClick={onClick}
-        aria-label={source ? title : undefined}
-        className={cn(
-          'inline-flex items-center justify-center',
-          'min-w-5 h-5 px-1 mx-0.5',
-          'text-xs font-medium rounded',
-          'bg-primary/10 text-primary hover:bg-primary/20',
-          'transition-colors cursor-pointer',
-          'align-middle'
-        )}
-        render={<button />}
-      >
-        {index}
-      </TooltipTrigger>
-      <TooltipContent>{title}</TooltipContent>
-    </Tooltip>
-  )
-}

--- a/frontend/components/chat/message.test.tsx
+++ b/frontend/components/chat/message.test.tsx
@@ -97,8 +97,16 @@ mock.module('@/components/ai-elements/tool', () => ({
   ToolInput: ({ input }: { input: unknown }) => <pre>{JSON.stringify(input)}</pre>,
   ToolOutput: ({ output, errorText }: { output?: unknown; errorText?: string }) => <pre>{errorText ?? JSON.stringify(output)}</pre>,
 }))
+mock.module('@/components/ai-elements/inline-citation', () => ({
+  InlineCitation: ({ children, ...props }: React.ComponentProps<'span'>) => <span {...props}>{children}</span>,
+  InlineCitationCard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  InlineCitationCardBody: ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
+  InlineCitationCardTrigger: ({ label, sources, ...props }: React.ComponentProps<'button'> & { label?: React.ReactNode; sources: string[] }) => <button type="button" data-source-count={sources.length} {...props}>{label}</button>,
+  InlineCitationQuote: ({ children, ...props }: React.ComponentProps<'blockquote'>) => <blockquote {...props}>{children}</blockquote>,
+  InlineCitationSource: ({ children, title, url, ...props }: React.ComponentProps<'div'> & { title?: string; url?: string }) => <div {...props}>{title && <h4>{title}</h4>}{url && <p>{url}</p>}{children}</div>,
+}))
 mock.module('./image-lightbox', () => ({ ImageLightbox: ({ src, alt, isOpen }: { src: string; alt: string; isOpen: boolean }) => isOpen ? <div role="dialog" aria-label={alt}>{src}</div> : null, useLightbox: () => ({ isOpen: false, imageSrc: '', imageAlt: '', openLightbox, closeLightbox: mock(() => {}) }) }))
-mock.module('./message-parts', () => ({ SourceContent: ({ sources }: { sources: unknown[] }) => <aside>sources:{sources.length}</aside> }))
+mock.module('./message-parts', () => ({ SourceContent: ({ sources }: { sources: Array<{ sourceId?: string }> }) => <aside>sources:{sources.length}:{sources.map(source => source.sourceId).join(',')}</aside> }))
 mock.module('streamdown', () => ({
   Block: ({ content }: { content: string }) => (
     <div data-streamdown="code-block">
@@ -451,8 +459,9 @@ describe('message behavior', () => {
         id: 'mixed',
         role: 'assistant',
         parts: [
-          { type: 'source-url', url: 'https://example.test', title: 'Example' },
-          { type: 'source-document', documentName: 'Guide', content: 'Citation' },
+          { type: 'text', text: 'Web[[cite:web_source]] Document[[cite:doc_source]]', state: 'done' },
+          { type: 'source-url', sourceId: 'web_source', url: 'https://example.test', title: 'Example' },
+          { type: 'source-document', sourceId: 'doc_source', documentName: 'Guide', content: 'Citation' },
           { type: 'file', filename: 'hidden.pdf', url: '/hidden.pdf' },
           { type: 'image', url: '/uploaded.png', alt: 'Uploaded chart' },
           { type: 'media-result', output: { kind: 'media.video', success: true, prompt: 'Demo', status: 'processing', progress: 0.42 } },
@@ -467,6 +476,32 @@ describe('message behavior', () => {
     expect(html).toContain('chat.message.videoProcessing')
     expect(html).toContain('chat.message.progress')
     expect(html).toContain('chat.message.outputTruncated')
+  })
+
+  test('lists only sources cited by the assistant answer', () => {
+    const cited = renderToStaticMarkup(<Message message={{
+      id: 'partially-cited',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'Supported claim[[cite:used_source]]', state: 'done' },
+        { type: 'source-url', sourceId: 'used_source', url: 'https://example.test/used' },
+        { type: 'source-url', sourceId: 'unused_source', url: 'https://example.test/unused' },
+      ],
+    }} />)
+    const uncited = renderToStaticMarkup(<Message message={{
+      id: 'uncited',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'No source marker', state: 'done' },
+        { type: 'source-document', sourceId: 'unused_document', documentName: 'Unused', content: 'Unused material' },
+      ],
+    }} />)
+
+    expect(cited).toContain('sources:1')
+    expect(cited).not.toContain('sources:2')
+    expect(cited).toContain('used_source')
+    expect(cited).not.toContain('unused_source')
+    expect(uncited).not.toContain('sources:')
   })
 
 
@@ -582,7 +617,7 @@ describe('message behavior', () => {
     expect(thought?.querySelector('h3')?.textContent).toBe('chat.reasoning.actionCallingToolsParallel count=2')
     expect([...container.querySelectorAll('[data-step-status]')].map((item) => item.getAttribute('data-step-status'))).toEqual(['complete', 'active', 'active', 'active', 'error', 'pending', 'error'])
     expect(container.querySelector('[data-streaming="true"]')).not.toBeNull()
-    expect([...container.querySelectorAll('[data-tool-state]')].map((item) => item.getAttribute('data-tool-state'))).toEqual(['input-available', 'output-error', 'input-streaming'])
+    expect([...container.querySelectorAll('[data-tool-state]')].map((item) => item.getAttribute('data-tool-state'))).toEqual(['output-available', 'input-available', 'output-error', 'input-streaming'])
 
     act(() => button(container, 'toggle reasoning').click())
     expect(onOpenChange).toHaveBeenCalledWith(false)
@@ -660,6 +695,63 @@ describe('message behavior', () => {
     />)
     expect(finalStep).toContain('chat.reasoning.thoughtFor seconds=2')
     expect(finalStep).not.toContain('chat.reasoning.thinkingDefault')
+  })
+
+  test('keeps thought process actively updating during later tool iterations even with text present', () => {
+    const multiRoundExecuting = renderToStaticMarkup(<Message
+      isStreaming
+      message={{
+        id: 'multi-round-executing',
+        role: 'assistant',
+        parts: [
+          { type: 'reasoning', text: 'First round done', state: 'done', duration: 1500 },
+          { type: 'text', text: 'I will now search the web for more information.', state: 'streaming' },
+          { type: 'tool-call', toolCallId: 't2', toolName: 'web_search', input: { q: 'latest' }, state: 'running' },
+        ],
+      }}
+    />)
+    expect(multiRoundExecuting).toContain('data-chat-thought-process="true"')
+    expect(multiRoundExecuting).toContain('data-streaming="true"')
+    expect(multiRoundExecuting).toContain('<h3>chat.reasoning.actionSearchingWeb</h3>')
+    expect(multiRoundExecuting).not.toContain('<h3>chat.reasoning.thoughtFor')
+  })
+
+  test('renders naive rag in thought process as an expandable tool-like card with parameters and results', () => {
+    const container = render(<Message
+      chainOfThoughtOpen
+      message={{
+        id: 'rag-detail-message',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'task',
+            taskType: 'rag',
+            state: 'completed',
+            info: {
+              count: 1,
+              query: 'how to configure',
+              contexts: [
+                {
+                  document_id: 'doc-1',
+                  document_name: 'Config Guide',
+                  content: 'Relevant snippet content',
+                  score: 0.95,
+                  kb_name: 'Manual',
+                },
+              ],
+            },
+          },
+          { type: 'text', text: 'Here is the answer', state: 'done' },
+        ],
+      }}
+    />)
+    const thought = container.querySelector('[data-chat-thought-process="true"]')
+    expect(thought).not.toBeNull()
+    expect(thought?.textContent).toContain('chat.task.foundSources')
+    expect(thought?.textContent).toContain('chat.task.searchingKnowledge')
+    expect(thought?.textContent).toContain('how to configure')
+    expect(thought?.textContent).toContain('Config Guide')
+    expect(thought?.textContent).toContain('Relevant snippet content')
   })
 
 
@@ -977,7 +1069,7 @@ describe('message behavior', () => {
     })
   })
 
-  test('normalizes citations, strong markers, and math outside code', () => {
+  test('normalizes strong markers and math outside code without altering text markers', () => {
     const html = renderToStaticMarkup(<Message message={{
       id: 'normalized-text',
       role: 'assistant',
@@ -988,16 +1080,51 @@ describe('message behavior', () => {
     }} />)
 
     expect(html).toContain('&lt;strong&gt;Bold&lt;/strong&gt;suffix')
-    expect(html).toContain(' [1]')
-    expect(html).not.toContain('(ref:9)')
+    expect(html).toContain('[ref:1]')
+    expect(html).toContain('(ref:9)')
     expect(html).toContain('$$')
-    expect(html).toContain('` [1]`')
   })
 
-  test('copies citation-free text and reports clipboard failures', async () => {
+  test('renders canonical and legacy known citation markers as inline source cards', () => {
+    const legacyCitationMarker = '\ue200cite\ue202web_b2\ue200'
+    renderToStaticMarkup(<Message message={{
+      id: 'cited-answer',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'text',
+          text: `Supported claim[[cite:web_b2]] Legacy${legacyCitationMarker} Unknown[[cite:missing]]`,
+          state: 'done',
+        },
+        { type: 'source-url', sourceId: 'web_b2', title: 'News', url: 'https://example.test/news', snippet: 'Latest update' },
+      ],
+    }} />)
+
+    expect(lastStreamdownProps.children).toBe('Supported claim[1](#clouisle-citation=web_b2) Legacy[1](#clouisle-citation=web_b2) Unknown')
+    const CitationLink = (lastStreamdownProps.components as {
+      a: React.ComponentType<React.ComponentProps<'a'>>
+    }).a
+    const card = renderToStaticMarkup(<CitationLink href="#clouisle-citation=web_b2">1</CitationLink>)
+    expect(card).toContain('data-citation-id="web_b2"')
+    expect(card).toContain('News')
+    expect(card).toContain('https://example.test/news')
+    expect(card).toContain('Latest update')
+
+    renderToStaticMarkup(<Message
+      isStreaming
+      message={{
+        id: 'streaming-citation',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Still writing[[cite:web_', state: 'streaming' }],
+      }}
+    />)
+    expect(lastStreamdownProps.children).toBe('Still writing')
+  })
+
+  test('copies full message text and reports clipboard failures', async () => {
     const writeText = mock(async () => {})
     Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
-    const container = render(<Message message={{ id: 'copy', role: 'assistant', parts: [{ type: 'text', text: 'Answer [[cite:1]]' }] }} />)
+    const container = render(<Message message={{ id: 'copy', role: 'assistant', parts: [{ type: 'text', text: 'Answer[[cite:web_b2]]' }] }} />)
 
     await act(async () => button(container, 'chat.message.copy').click())
     expect(writeText).toHaveBeenCalledWith('Answer')
@@ -1037,7 +1164,7 @@ describe('message behavior', () => {
     ;(globalThis as typeof globalThis & { SpeechSynthesisUtterance: typeof Utterance }).SpeechSynthesisUtterance = Utterance
     const onRequestScrollIntoView = mock(() => {})
     const container = render(<Message
-      message={{ id: 'speech', role: 'assistant', parts: [{ type: 'text', text: '# Dr. Smith has **one** item. Next item! `code` 🎉' }] }}
+      message={{ id: 'speech', role: 'assistant', parts: [{ type: 'text', text: '# Dr. Smith has **one** item. Next item! `code` 🎉[[cite:web_b2]]' }] }}
       onRequestScrollIntoView={onRequestScrollIntoView}
     />)
     await act(async () => {})

--- a/frontend/components/chat/message.test.tsx
+++ b/frontend/components/chat/message.test.tsx
@@ -754,6 +754,38 @@ describe('message behavior', () => {
     expect(thought?.textContent).toContain('Relevant snippet content')
   })
 
+  test('recognizes citations with citation_id prefix inside bold list items', () => {
+    const container = render(<Message
+      message={{
+        id: 'citation-prefix-tolerance',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: '- **纽约与洛杉矶学区暂停部分生成式 AI 使用**[[citation_id:web_ff0d501c1315fba5]]。',
+            state: 'done',
+          },
+          {
+            type: 'source-url',
+            sourceId: 'web_ff0d501c1315fba5',
+            url: 'https://example.com/ai-news',
+            title: 'AI in Schools',
+          },
+        ],
+      }}
+    />)
+
+    expect(container.textContent).toContain('纽约与洛杉矶学区暂停部分生成式 AI 使用')
+    expect(container.textContent).not.toContain('[[citation_id:web_ff0d501c1315fba5]]')
+    expect(container.textContent).toContain('[1](#clouisle-citation=web_ff0d501c1315fba5)')
+    const CitationLink = (lastStreamdownProps.components as {
+      a: React.ComponentType<React.ComponentProps<'a'>>
+    }).a
+    const card = renderToStaticMarkup(<CitationLink href="#clouisle-citation=web_ff0d501c1315fba5">1</CitationLink>)
+    expect(card).toContain('AI in Schools')
+    expect(card).toContain('https://example.com/ai-news')
+  })
+
 
   test('renders compression at its original reasoning timeline position', () => {
     const container = render(<Message

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -88,9 +88,9 @@ import {
   shouldDisplayMediaResultInBody,
 } from '@/lib/utils/tool-result'
 
-const CITATION_MARKER_REGEX = /\[\[cite:([A-Za-z0-9_-]{1,128})\]\]/g
-const CITATION_PROTOCOL_MARKER_REGEX = /\[\[cite:[^\]\r\n]{0,256}\]\]/g
-const INCOMPLETE_CITATION_SUFFIX_REGEX = /\[\[(?:c|ci|cit|cite|cite:[^\]\r\n]*)?$/
+const CITATION_MARKER_REGEX = /\[\[(?:cite|citation|citation_id):([A-Za-z0-9_-]{1,128})\]\]/g
+const CITATION_PROTOCOL_MARKER_REGEX = /\[\[(?:cite|citation|citation_id):[^\]\r\n]{0,256}\]\]/g
+const INCOMPLETE_CITATION_SUFFIX_REGEX = /\[\[(?:c|ci|cit|cite|citation|citation_id)(?::[^\]\r\n]*)?$/
 const LEGACY_CITATION_MARKER_REGEX = /\ue200cite\ue202([A-Za-z0-9_-]{1,128})\ue200/g
 const LEGACY_CITATION_PROTOCOL_MARKER_REGEX = /\ue200cite\ue202[^\ue200]*\ue200/g
 const LEGACY_INCOMPLETE_CITATION_SUFFIX_REGEX = /\ue200(?:cite(?:\ue202[^\ue200]*)?)?$/
@@ -1977,7 +1977,7 @@ function collectCitedSourceIds(parts: MessagePart[]) {
   for (const part of parts) {
     if (!isTextPart(part)) continue
     const text = part.text
-    if (!text || (!text.includes('[[cite:') && !text.includes('\ue200cite'))) continue
+    if (!text || (!text.includes('[[') && !text.includes('\ue200cite'))) continue
 
     if (!text.includes('`')) {
       for (const match of text.matchAll(CITATION_MARKER_REGEX)) {
@@ -1991,7 +1991,7 @@ function collectCitedSourceIds(parts: MessagePart[]) {
 
     for (const segment of text.split(CODE_BLOCK_REGEX)) {
       if (!segment || segment.startsWith('`')) continue
-      if (!segment.includes('[[cite:') && !segment.includes('\ue200cite')) continue
+      if (!segment.includes('[[') && !segment.includes('\ue200cite')) continue
       for (const match of segment.matchAll(CITATION_MARKER_REGEX)) {
         sourceIds.add(match[1])
       }

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -51,7 +51,15 @@ import {
   ToolInput,
   ToolOutput,
 } from '@/components/ai-elements/tool'
-import type { ChatMessage, ChatPreviewPayload, CodePreviewPayload, MessagePart, SourceDocumentPart, SourceUrlPart, FilePart, ImagePart, TaskPart, ToolCallPart, McpToolCallPart, MediaResultPart } from './types'
+import {
+  InlineCitation,
+  InlineCitationCard,
+  InlineCitationCardBody,
+  InlineCitationCardTrigger,
+  InlineCitationQuote,
+  InlineCitationSource,
+} from '@/components/ai-elements/inline-citation'
+import type { ChatMessage, ChatPreviewPayload, CodePreviewPayload, MessagePart, CitationSourcePart, FilePart, ImagePart, TaskPart, ToolCallPart, McpToolCallPart, MediaResultPart } from './types'
 import {
   isTextPart,
   isReasoningPart,
@@ -80,6 +88,24 @@ import {
   shouldDisplayMediaResultInBody,
 } from '@/lib/utils/tool-result'
 
+const CITATION_MARKER_REGEX = /\[\[cite:([A-Za-z0-9_-]{1,128})\]\]/g
+const CITATION_PROTOCOL_MARKER_REGEX = /\[\[cite:[^\]\r\n]{0,256}\]\]/g
+const INCOMPLETE_CITATION_SUFFIX_REGEX = /\[\[(?:c|ci|cit|cite|cite:[^\]\r\n]*)?$/
+const LEGACY_CITATION_MARKER_REGEX = /\ue200cite\ue202([A-Za-z0-9_-]{1,128})\ue200/g
+const LEGACY_CITATION_PROTOCOL_MARKER_REGEX = /\ue200cite\ue202[^\ue200]*\ue200/g
+const LEGACY_INCOMPLETE_CITATION_SUFFIX_REGEX = /\ue200(?:cite(?:\ue202[^\ue200]*)?)?$/
+const CITATION_HREF_PREFIX = '#clouisle-citation='
+
+function stripCitationMarkers(text: string) {
+  if (!text || (!text.includes('[[') && !text.includes('\ue200'))) {
+    return text || ''
+  }
+  return text
+    .replace(CITATION_PROTOCOL_MARKER_REGEX, '')
+    .replace(LEGACY_CITATION_PROTOCOL_MARKER_REGEX, '')
+    .replace(INCOMPLETE_CITATION_SUFFIX_REGEX, '')
+    .replace(LEGACY_INCOMPLETE_CITATION_SUFFIX_REGEX, '')
+}
 const CODE_FENCE_REGEX = /^ {0,3}(`{3,}|~{3,})([^\r\n]*)\r?\n([\s\S]*?)(?:\r?\n)?(`{3,}|~{3,})[ \t\r\n]*$/
 const STREAMING_REHYPE_PLUGINS = [
   defaultRehypePlugins.sanitize,
@@ -160,7 +186,7 @@ function getSpeechSynthesis() {
 const SPEECH_EMOJI_REGEX = /(?:\p{Extended_Pictographic}|\p{Regional_Indicator}|[☀-➿])[️︎]?(?:‍(?:\p{Extended_Pictographic}|\p{Regional_Indicator}|[☀-➿])[️︎]?)*|[\u{1F3FB}-\u{1F3FF}]/gu
 
 function getSpeechText(text: string) {
-  return text
+  return stripCitationMarkers(text)
     .replace(/```[\s\S]*?```/g, '')
     .replace(/`([^`]+)`/g, '$1')
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
@@ -493,22 +519,17 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
     // renderers use the original message index for stable keys and callbacks.
     const {
       allSources,
-      documentSources,
       otherParts,
       otherPartEntries,
       hasIterationCapMarker,
     } = React.useMemo(() => {
-      const nextAllSources: Array<SourceUrlPart | SourceDocumentPart> = []
-      const nextDocumentSources: SourceDocumentPart[] = []
+      const nextAllSources: CitationSourcePart[] = []
       const nextOtherPartEntries: Array<{ part: MessagePart; index: number }> = []
       let nextHasIterationCapMarker = false
       const parts = message.parts || []
       for (const [index, part] of parts.entries()) {
         if (isSourcePart(part)) {
-          nextAllSources.push(part as SourceUrlPart | SourceDocumentPart)
-          if (isSourceDocumentPart(part)) {
-            nextDocumentSources.push(part)
-          }
+          nextAllSources.push(part as CitationSourcePart)
           continue
         }
 
@@ -520,12 +541,19 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
 
       return {
         allSources: nextAllSources,
-        documentSources: nextDocumentSources,
         otherParts: nextOtherPartEntries.map(({ part }) => part),
         otherPartEntries: nextOtherPartEntries,
         hasIterationCapMarker: nextHasIterationCapMarker,
       }
     }, [message.parts])
+    const citedSources = React.useMemo(() => {
+      if (allSources.length === 0) return []
+      const citedSourceIds = collectCitedSourceIds(otherParts)
+      if (citedSourceIds.size === 0) return []
+      return allSources.filter(source => (
+        source.sourceId ? citedSourceIds.has(source.sourceId) : false
+      ))
+    }, [allSources, otherParts])
     const iterationCapLabel = t('iterationCapReached').trim()
     const taskParts = React.useMemo(() => otherParts.filter(isTaskPart), [otherParts])
     const reasoningParts = React.useMemo(() => otherParts.filter(isReasoningPart), [otherParts])
@@ -537,7 +565,7 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
     const hasReasoning = reasoningParts.length > 0
 
 
-    // Get text content for copying (strip citation markers)
+    // Get text content for copying
     const textContent = React.useMemo(() => {
       const parts: string[] = []
       for (const part of message.parts || []) {
@@ -545,7 +573,7 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
           isTextPart(part)
           && !(hasIterationCapMarker && part.text.trim() === iterationCapLabel)
         ) {
-          parts.push(part.text.replace(/\[\[cite:\d+\]\]/g, ''))
+          parts.push(stripCitationMarkers(part.text))
         }
       }
       return parts.join('\n').trim()
@@ -842,7 +870,7 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
           <TextWithCitations
             key={index}
             text={part.text}
-            sources={documentSources}
+            sources={citedSources}
             isStreaming={isStreaming && part.state !== 'done'}
             activeSpeechSentence={activeSpeechSentence}
             onOpenCodePreview={onOpenCodePreview}
@@ -992,7 +1020,7 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
       return null
     }, [
       activeSpeechSentence,
-      documentSources,
+      citedSources,
       hasIterationCapMarker,
       hasReasoning,
       hideReasoning,
@@ -1059,14 +1087,21 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
     )
     const hasTasks = taskParts.length > 0
     const hasChainOfThought = (hasReasoning || hasTasks) && !hideReasoning
-    const isChainOfThoughtStreaming = !hasTextContent && (
+    const activeToolActions = React.useMemo(() => {
+      return getActiveToolActions(message.parts || [])
+    }, [message.parts])
+    const hasActiveThoughtActivity = (
       taskParts.some(part => part.state === 'running')
       || reasoningParts.some(part => part.state === 'streaming')
-      || (hasReasoning && toolCallParts.some(part => (
+      || activeToolActions.length > 0
+      || toolCallParts.some(part => (
         (isToolCallPart(part) || isMcpToolCallPart(part))
         && (part.state === 'pending' || part.state === 'running')
-      )))
-      || isStreaming
+      ))
+    )
+    const isChainOfThoughtStreaming = Boolean(
+      hasActiveThoughtActivity
+      || (isStreaming && !hasTextContent)
     )
 
     // Compute total reasoning duration if available
@@ -1082,12 +1117,9 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
       return hasDuration ? totalMs : null
     }, [reasoningParts])
 
-    const activeToolActions = React.useMemo(() => {
-      return getActiveToolActions(message.parts || [])
-    }, [message.parts])
 
     const chainOfThoughtTitle = React.useMemo(() => {
-      if (isChainOfThoughtStreaming) {
+      if (hasActiveThoughtActivity) {
         if (activeToolActions.length === 1) {
           const action = activeToolActions[0]
           switch (action.category) {
@@ -1113,12 +1145,15 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
         }
         return tReasoning('thinkingDefault')
       }
+      if (isStreaming && !hasTextContent) {
+        return tReasoning('thinkingDefault')
+      }
       if (totalReasoningDuration !== null) {
         const seconds = Math.max(1, Math.ceil(totalReasoningDuration / 1000))
         return tReasoning('thoughtFor', { seconds })
       }
       return tReasoning('thought')
-    }, [activeToolActions, isChainOfThoughtStreaming, totalReasoningDuration, tReasoning])
+    }, [activeToolActions, hasActiveThoughtActivity, hasTextContent, isStreaming, totalReasoningDuration, tReasoning])
     // Convert task state to step status
     const getStepStatus = React.useCallback((state: TaskPart['state']) => {
       switch (state) {
@@ -1132,8 +1167,10 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
     // Render task title based on type and state
     const getTaskTitle = React.useCallback((taskPart: TaskPart) => {
       if (taskPart.taskType === 'rag') {
-        if (taskPart.state === 'completed' && typeof taskPart.info === 'number') {
-          return tTask('foundSources', { count: taskPart.info })
+        const info = (taskPart.info && typeof taskPart.info === 'object') ? taskPart.info as Record<string, unknown> : null
+        const sourceCount = typeof info?.count === 'number' ? info.count : typeof taskPart.info === 'number' ? taskPart.info : null
+        if (taskPart.state === 'completed' && sourceCount !== null) {
+          return tTask('foundSources', { count: sourceCount })
         }
         return tTask('searchingKnowledge')
       }
@@ -1214,13 +1251,55 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
       const steps: React.ReactNode[] = []
 
       taskParts.filter(part => part.taskType === 'rag').forEach((taskPart, index) => {
+        const info = (taskPart.info && typeof taskPart.info === 'object') ? taskPart.info as Record<string, unknown> : null
+        const query = typeof info?.query === 'string' ? info.query : undefined
+        const contexts = Array.isArray(info?.contexts)
+          ? info.contexts
+          : allSources.filter(isSourceDocumentPart).map((src) => ({
+              document_id: src.documentId,
+              document_name: src.documentName,
+              content: src.content,
+              score: src.metadata?.score,
+              kb_id: src.metadata?.kb_id,
+              kb_name: src.metadata?.kb_name,
+            }))
+        const toolState = taskPart.state === 'error'
+          ? 'output-error'
+          : taskPart.state === 'completed'
+            ? 'output-available'
+            : taskPart.state === 'running'
+              ? 'input-available'
+              : 'input-streaming'
+
         steps.push(
           <ChainOfThoughtStep
             key={`rag-${index}`}
             icon={SearchIcon}
             label={getTaskTitle(taskPart)}
             status={getStepStatus(taskPart.state)}
-          />
+          >
+            <Tool defaultOpen={false} className="mt-2">
+              <ToolHeader
+                title={tTask('searchingKnowledge')}
+                type="tool-call"
+                state={toolState}
+              />
+              <AIToolContent>
+                {query && (
+                  <ToolInput input={{ query }} />
+                )}
+                {taskPart.state === 'completed' && (
+                  <ToolOutput
+                    output={{
+                      count: contexts.length,
+                      contexts: contexts.length > 0 ? contexts : [],
+                    }}
+                    errorText={undefined}
+                  />
+                )}
+              </AIToolContent>
+            </Tool>
+          </ChainOfThoughtStep>
         )
       })
 
@@ -1313,6 +1392,7 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
 
       return steps
     }, [
+      allSources,
       getStepStatus,
       getTaskTitle,
       getToolCallLabel,
@@ -1322,6 +1402,7 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
       otherPartEntries,
       renderToolResultContent,
       tReasoning,
+      tTask,
       taskParts,
       toolResultsByCallIndex,
     ])
@@ -1436,12 +1517,12 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
           )}
         </MessageContent>
 
-        {isAssistant && allSources.length > 0 && (
-          <SourceContent sources={allSources} onOpenCodePreview={onOpenCodePreview} />
+        {isAssistant && citedSources.length > 0 && (
+          <SourceContent sources={citedSources} onOpenCodePreview={onOpenCodePreview} />
         )}
       </>
     ), [
-      allSources,
+      citedSources,
       buildChainOfThoughtSteps,
       cancelEdit,
       chainOfThoughtTitle,
@@ -1891,15 +1972,53 @@ const BARE_LATEX_FORMULA_LINE_REGEX = /^(\s*)(\\(?:cos|sin|tan|log|ln|text|frac|
 const MATH_COMMAND_REGEX = /\\[A-Za-z]+/
 const TIGHT_STRONG_MARKER_REGEX = /\*\*([^*\n]+?)\*\*(?=[\p{Script=Han}\p{Letter}\p{Number}])/gu
 
+function collectCitedSourceIds(parts: MessagePart[]) {
+  const sourceIds = new Set<string>()
+  for (const part of parts) {
+    if (!isTextPart(part)) continue
+    const text = part.text
+    if (!text || (!text.includes('[[cite:') && !text.includes('\ue200cite'))) continue
+
+    if (!text.includes('`')) {
+      for (const match of text.matchAll(CITATION_MARKER_REGEX)) {
+        sourceIds.add(match[1])
+      }
+      for (const match of segmentMatchAll(text, LEGACY_CITATION_MARKER_REGEX)) {
+        sourceIds.add(match[1])
+      }
+      continue
+    }
+
+    for (const segment of text.split(CODE_BLOCK_REGEX)) {
+      if (!segment || segment.startsWith('`')) continue
+      if (!segment.includes('[[cite:') && !segment.includes('\ue200cite')) continue
+      for (const match of segment.matchAll(CITATION_MARKER_REGEX)) {
+        sourceIds.add(match[1])
+      }
+      for (const match of segmentMatchAll(segment, LEGACY_CITATION_MARKER_REGEX)) {
+        sourceIds.add(match[1])
+      }
+    }
+  }
+  return sourceIds
+}
+
+function segmentMatchAll(text: string, regex: RegExp) {
+  return text.matchAll(regex)
+}
 function normalizeTightStrongMarkers(input: string) {
-  if (!input) {
-    return ''
+  if (!input || !input.includes('**')) {
+    return input || ''
+  }
+
+  if (!input.includes('`')) {
+    return input.replace(TIGHT_STRONG_MARKER_REGEX, '<strong>$1</strong>')
   }
 
   return input
     .split(CODE_BLOCK_REGEX)
     .map((segment) => {
-      if (!segment || segment.startsWith('`')) {
+      if (!segment || segment.startsWith('`') || !segment.includes('**')) {
         return segment
       }
       return segment.replace(TIGHT_STRONG_MARKER_REGEX, '<strong>$1</strong>')
@@ -1965,21 +2084,67 @@ function normalizeBareMathDelimiters(input: string) {
     .join('')
 }
 
-const CITE_MARKER_REGEX = /\[\[cite:(\d+)\]\]/g
-
-function normalizeCitationMarkers(input: string, normalizeMath: boolean) {
+function normalizeMessageText(input: string, normalizeMath: boolean) {
   const normalized = normalizeMath ? normalizeBareMathDelimiters(input) : input
   return normalizeTightStrongMarkers(normalized)
-    .replace(/\[\[ref:(\d+)\]\]/gi, '[[cite:$1]]')
-    .replace(/\[ref:(\d+)\]/gi, '[[cite:$1]]')
-    .replace(/\(ref:(\d+)\)/gi, '[[cite:$1]]')
 }
+function prepareCitationMarkdown(
+  text: string,
+  sources: CitationSourcePart[],
+  isStreaming: boolean
+) {
+  const normalizedText = normalizeMessageText(text, !isStreaming)
+  const hasCitationPrefix = normalizedText.includes('[[') || normalizedText.includes('\ue200')
 
-function formatCitationMarker(index: number, sources: SourceDocumentPart[]) {
-  if (index < 1 || index > sources.length) {
-    return ''
+  if (!hasCitationPrefix) {
+    return normalizedText
   }
-  return ` [${index}]`
+
+  let sourceIndexById: Map<string, number> | null = null
+  if (sources.length > 0) {
+    sourceIndexById = new Map()
+    for (let i = 0; i < sources.length; i++) {
+      const id = sources[i].sourceId
+      if (id && !sourceIndexById.has(id)) {
+        sourceIndexById.set(id, i + 1)
+      }
+    }
+  }
+
+  const renderCitation = (_marker: string, sourceId: string) => {
+    const index = sourceIndexById?.get(sourceId)
+    return index ? `[${index}](${CITATION_HREF_PREFIX}${encodeURIComponent(sourceId)})` : ''
+  }
+
+  if (!normalizedText.includes('`')) {
+    return normalizedText
+      .replace(CITATION_MARKER_REGEX, renderCitation)
+      .replace(LEGACY_CITATION_MARKER_REGEX, renderCitation)
+      .replace(CITATION_PROTOCOL_MARKER_REGEX, '')
+      .replace(LEGACY_CITATION_PROTOCOL_MARKER_REGEX, '')
+      .replace(INCOMPLETE_CITATION_SUFFIX_REGEX, '')
+      .replace(LEGACY_INCOMPLETE_CITATION_SUFFIX_REGEX, '')
+  }
+
+  return normalizedText
+    .split(CODE_BLOCK_REGEX)
+    .map((segment) => {
+      if (!segment) return ''
+      if (segment.startsWith('`')) {
+        return stripCitationMarkers(segment)
+      }
+      if (!segment.includes('[[') && !segment.includes('\ue200')) {
+        return segment
+      }
+      return segment
+        .replace(CITATION_MARKER_REGEX, renderCitation)
+        .replace(LEGACY_CITATION_MARKER_REGEX, renderCitation)
+        .replace(CITATION_PROTOCOL_MARKER_REGEX, '')
+        .replace(LEGACY_CITATION_PROTOCOL_MARKER_REGEX, '')
+        .replace(INCOMPLETE_CITATION_SUFFIX_REGEX, '')
+        .replace(LEGACY_INCOMPLETE_CITATION_SUFFIX_REGEX, '')
+    })
+    .join('')
 }
 
 export const TextWithCitations = React.memo(function TextWithCitations({
@@ -1991,25 +2156,17 @@ export const TextWithCitations = React.memo(function TextWithCitations({
   onOpenImage,
 }: {
   text: string
-  sources: SourceDocumentPart[]
+  sources: CitationSourcePart[]
   isStreaming?: boolean
   activeSpeechSentence?: string | null
   onOpenCodePreview?: (payload: ChatPreviewPayload) => void
   onOpenImage?: (src: string, alt?: string) => void
 }) {
   const containerRef = React.useRef<HTMLDivElement>(null)
-  const hasSources = sources.length > 0
 
-  const processedText = React.useMemo(() => {
-    const normalized = normalizeCitationMarkers(text, !isStreaming)
-    if (!hasSources) {
-      return normalized.replace(CITE_MARKER_REGEX, '')
-    }
-    return normalized.replace(CITE_MARKER_REGEX, (_, rawIndex: string) => (
-      formatCitationMarker(Number.parseInt(rawIndex, 10), sources)
-    ))
-  }, [text, hasSources, sources, isStreaming])
-
+  const processedText = React.useMemo(() => (
+    prepareCitationMarkdown(text, sources, isStreaming)
+  ), [text, sources, isStreaming])
   const clearSpeechHighlight = React.useCallback(() => {
     const highlightedElements = containerRef.current?.querySelectorAll('mark[data-speech-highlight="true"]')
     if (!highlightedElements) {
@@ -2094,6 +2251,38 @@ export const TextWithCitations = React.memo(function TextWithCitations({
   const rehypePlugins = isStreaming ? STREAMING_REHYPE_PLUGINS : undefined
 
   const components = React.useMemo(() => ({
+    a: ({ href, children, ...props }: React.ComponentProps<'a'>) => {
+      if (!href?.startsWith(CITATION_HREF_PREFIX)) {
+        return <a href={href} {...props}>{children}</a>
+      }
+      const encodedSourceId = href.slice(CITATION_HREF_PREFIX.length)
+      const source = sources.find((candidate) => (
+        candidate.sourceId && encodeURIComponent(candidate.sourceId) === encodedSourceId
+      ))
+      if (!source) return null
+
+      const isUrlSource = source.type === 'source-url'
+      const url = isUrlSource ? source.url : undefined
+      const title = isUrlSource ? source.title : source.documentName
+      const description = isUrlSource ? source.snippet : source.content
+
+      return (
+        <InlineCitation data-citation-id={source.sourceId}>
+          <InlineCitationCard>
+            <InlineCitationCardTrigger
+              sources={url ? [url] : [title || source.sourceId || 'source']}
+              label={children}
+              aria-label={title || source.sourceId}
+            />
+            <InlineCitationCardBody className="p-3.5 max-w-[24rem]">
+              <InlineCitationSource title={title} url={url}>
+                {description && <InlineCitationQuote>{description}</InlineCitationQuote>}
+              </InlineCitationSource>
+            </InlineCitationCardBody>
+          </InlineCitationCard>
+        </InlineCitation>
+      )
+    },
     img: ({ src, alt, ...props }: React.ComponentProps<'img'>) => (
       <AuthenticatedMarkdownImage
         src={typeof src === 'string' ? src : undefined}
@@ -2120,7 +2309,7 @@ export const TextWithCitations = React.memo(function TextWithCitations({
       }
       return <p {...props}>{children}</p>
     },
-  }), [onOpenImage])
+  }), [onOpenImage, sources])
 
   const renderMarkdownBlock = React.useCallback((props: React.ComponentProps<typeof Block>) => (
     <PreviewableMarkdownBlock

--- a/frontend/components/chat/types.ts
+++ b/frontend/components/chat/types.ts
@@ -105,6 +105,8 @@ export interface SourceDocumentPart {
   }
 }
 
+export type CitationSourcePart = SourceUrlPart | SourceDocumentPart
+
 /**
  * File/Document part - for uploaded documents
  */

--- a/frontend/hooks/use-chat-issue255.test.ts
+++ b/frontend/hooks/use-chat-issue255.test.ts
@@ -63,6 +63,7 @@ mock.module('@/lib/api/client', () => ({ getErrorMessage: (key: string) => `api.
 mock.module('@/lib/utils/message-converter', () => ({ convertBackendMessages: (messages: Message[]) => messages }))
 mock.module('@/lib/utils/tool-result', () => ({
   parseToolResultOutput: (output: unknown) => output,
+  extractToolCitationSources: () => [],
   shouldDisplayMediaResultInBody: (output: { hidden?: boolean }) => !output.hidden,
 }))
 

--- a/frontend/hooks/use-chat.test.ts
+++ b/frontend/hooks/use-chat.test.ts
@@ -76,6 +76,22 @@ mock.module('@/lib/utils/message-converter', () => ({
 
 mock.module('@/lib/utils/tool-result', () => ({
   parseToolResultOutput: (output: unknown) => output,
+  extractToolCitationSources: (toolName: string, output: unknown) => {
+    const results = toolName === 'web_search' && output && typeof output === 'object' && 'results' in output && Array.isArray(output.results)
+      ? output.results
+      : []
+    return results.flatMap((result) => (
+      result && typeof result === 'object' && 'citation_id' in result && typeof result.citation_id === 'string'
+        ? [{
+            type: 'url' as const,
+            citationId: result.citation_id,
+            title: 'title' in result && typeof result.title === 'string' ? result.title : undefined,
+            content: 'content' in result && typeof result.content === 'string' ? result.content : undefined,
+            url: 'url' in result && typeof result.url === 'string' ? result.url : undefined,
+          }]
+        : []
+    ))
+  },
   shouldDisplayMediaResultInBody: () => true,
 }))
 
@@ -892,13 +908,13 @@ describe('useChat', () => {
       { event: 'reasoning_start', data: {} },
       { event: 'reasoning_delta', data: { delta: 'think' } },
       { event: 'reasoning_end', data: {} },
-      { event: 'rag_context', data: { contexts: [{ document_id: 'doc-1', document_name: 'Doc', content: 'chunk', kb_id: 'kb-1', kb_name: 'KB', score: 0.8 }] } },
+      { event: 'rag_context', data: { contexts: [{ citation_id: 'rag_doc_1', document_id: 'doc-1', document_name: 'Doc', content: 'chunk', kb_id: 'kb-1', kb_name: 'KB', score: 0.8 }] } },
       { event: 'compression_start', data: {} },
       { event: 'compression_end', data: { before_tokens: 20, after_tokens: 10 } },
-      { event: 'tool_call', data: { tool_call_id: 'tool-1', tool_name: 'sea', tool_display_name: 'sea', arguments: {} } },
-      { event: 'tool_call', data: { tool_call_id: 'tool-1', tool_name: 'search', tool_display_name: 'Search', arguments: { q: 'coverage' } } },
+      { event: 'tool_call', data: { tool_call_id: 'tool-1', tool_name: 'web', tool_display_name: 'web', arguments: {} } },
+      { event: 'tool_call', data: { tool_call_id: 'tool-1', tool_name: 'web_search', tool_display_name: 'Search', arguments: { q: 'coverage' } } },
       { event: 'tool_call', data: { tool_call_id: 'tool-2', tool_name: 'lookup', tool_display_name: 'Lookup', arguments: {} } },
-      { event: 'tool_result', data: { tool_call_id: 'tool-1', tool_name: 'search', tool_display_name: 'Search', result: { ok: true }, is_error: false } },
+      { event: 'tool_result', data: { tool_call_id: 'tool-1', tool_name: 'web_search', tool_display_name: 'Search', result: { success: true, results: [{ citation_id: 'web_result_1', title: 'Result', url: 'https://example.test/result', content: 'Web excerpt' }] }, is_error: false } },
       { event: 'tool_result', data: { tool_call_id: 'tool-2', tool_name: 'lookup', tool_display_name: 'Lookup', result: 'failed', is_error: true } },
       { event: 'media_result', data: { kind: 'image', url: '/cat.png' } },
       { event: 'output_truncated', data: {} },
@@ -912,6 +928,8 @@ describe('useChat', () => {
     const parts = result.messages[1].parts
     expect(parts.map((part) => part.type)).toContain('reasoning')
     expect(parts).toContainEqual(expect.objectContaining({ type: 'source-document', documentId: 'doc-1' }))
+    expect(parts).toContainEqual(expect.objectContaining({ type: 'source-document', sourceId: 'rag_doc_1' }))
+    expect(parts).toContainEqual(expect.objectContaining({ type: 'source-url', sourceId: 'web_result_1', url: 'https://example.test/result' }))
     expect(parts).toContainEqual(expect.objectContaining({ type: 'task', taskType: 'compression', state: 'completed' }))
     const reasoningIndex = parts.findIndex((part) => part.type === 'reasoning')
     const compressionIndex = parts.findIndex((part) => part.type === 'task' && part.taskType === 'compression')
@@ -923,7 +941,7 @@ describe('useChat', () => {
     expect(parts).toContainEqual(expect.objectContaining({
       type: 'tool-call',
       toolCallId: 'tool-1',
-      toolName: 'search',
+      toolName: 'web_search',
       input: { q: 'coverage' },
     }))
     expect(parts).toContainEqual(expect.objectContaining({ type: 'tool-call', toolCallId: 'tool-2', state: 'error' }))

--- a/frontend/hooks/use-chat.test.tsx
+++ b/frontend/hooks/use-chat.test.tsx
@@ -61,6 +61,7 @@ mock.module('@/lib/api/client', () => ({
 
 mock.module('@/lib/utils/tool-result', () => ({
   parseToolResultOutput: (output: unknown) => output,
+  extractToolCitationSources: () => [],
   shouldDisplayMediaResultInBody: () => true,
 }))
 mock.module('@/lib/utils/message-converter', () => ({

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -1882,6 +1882,7 @@ function createAssistantStreamStateFromParts(parts: MessagePart[]): AssistantStr
         break
       }
       case 'source-document':
+      case 'source-url':
         state.ragSources.push(part)
         break
       case 'media-result':

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -35,6 +35,7 @@ import type {
   TextPart,
   ReasoningPart,
   SourceDocumentPart,
+  SourceUrlPart,
   TaskPart,
   ToolCallPart,
   ToolResultPart,
@@ -43,7 +44,7 @@ import type {
   MediaResultPart,
 } from '@/components/chat'
 import { getErrorMessage as getApiErrorMessage } from '@/lib/api/client'
-import { parseToolResultOutput, shouldDisplayMediaResultInBody } from '@/lib/utils/tool-result'
+import { extractToolCitationSources, parseToolResultOutput, shouldDisplayMediaResultInBody } from '@/lib/utils/tool-result'
 
 export type ChatStatus = 'idle' | 'loading' | 'streaming' | 'error'
 
@@ -1631,7 +1632,7 @@ interface StreamingState {
   segments: ContentSegment[]
   reasoningBlocks: Array<{ text: string; startTime: number; duration?: number; state: 'streaming' | 'done' }>
   currentReasoningIndex: number
-  ragSources: SourceDocumentPart[]
+  ragSources: Array<SourceDocumentPart | SourceUrlPart>
   taskState: TaskState
 }
 
@@ -1955,7 +1956,7 @@ interface AssistantStreamState {
   segments: ContentSegment[]
   reasoningBlocks: Array<{ text: string; startTime: number; duration?: number; state: 'streaming' | 'done' }>
   currentReasoningIndex: number
-  ragSources: SourceDocumentPart[]
+  ragSources: Array<SourceDocumentPart | SourceUrlPart>
   taskState: TaskState
 }
 
@@ -2139,7 +2140,7 @@ function applyAssistantStreamEvent(
       const data = event.data as SSERagContext
       state.ragSources = data.contexts.map(context => ({
         type: 'source-document' as const,
-        sourceId: context.document_id,
+        sourceId: context.citation_id || context.document_id,
         documentId: context.document_id,
         documentName: context.document_name,
         content: context.content,
@@ -2151,7 +2152,11 @@ function applyAssistantStreamEvent(
       }))
       state.taskState.rag = 'completed'
       state.taskState.ragSourceCount = state.ragSources.length
-      ensureTimelineTask(state.segments, 'rag', 'completed', state.ragSources.length)
+      ensureTimelineTask(state.segments, 'rag', 'completed', {
+        count: state.ragSources.length,
+        query: data.query,
+        contexts: data.contexts,
+      })
       return true
     }
 
@@ -2196,6 +2201,29 @@ function applyAssistantStreamEvent(
         toolDisplayName: data.tool_display_name,
         output: parseToolResultOutput(data.result),
         isError: data.is_error,
+      }
+      const knownSourceIds = new Set(state.ragSources.map((source) => source.sourceId).filter(Boolean))
+      for (const source of extractToolCitationSources(data.tool_name, result.output)) {
+        if (knownSourceIds.has(source.citationId)) continue
+        knownSourceIds.add(source.citationId)
+        if (source.type === 'url' && source.url) {
+          state.ragSources.push({
+            type: 'source-url',
+            sourceId: source.citationId,
+            url: source.url,
+            title: source.title,
+            snippet: source.content,
+          })
+        } else if (source.type === 'document') {
+          state.ragSources.push({
+            type: 'source-document',
+            sourceId: source.citationId,
+            documentId: source.documentId,
+            documentName: source.title,
+            content: source.content || '',
+            metadata: source.metadata,
+          })
+        }
       }
       const existingSegment = findToolSegment(state.segments, data.tool_call_id)
       if (existingSegment) {
@@ -2248,7 +2276,7 @@ function applyAssistantStreamEvent(
  */
 function buildMessageParts(
   segments: ContentSegment[],
-  sources: SourceDocumentPart[],
+  sources: Array<SourceDocumentPart | SourceUrlPart>,
   isStreaming: boolean
 ): MessagePart[] {
   const parts: MessagePart[] = []
@@ -2295,7 +2323,7 @@ function buildMessageParts(
 
 function hasRenderableStreamingProgress(
   segments: ContentSegment[],
-  ragSources: SourceDocumentPart[],
+  ragSources: Array<SourceDocumentPart | SourceUrlPart>,
   taskState: TaskState
 ): boolean {
   return (
@@ -2319,7 +2347,7 @@ function buildErroredMessageParts(state: {
   segments: ContentSegment[]
   reasoningBlocks: Array<{ text: string; startTime: number; duration?: number; state: 'streaming' | 'done' }>
   currentReasoningIndex?: number
-  ragSources: SourceDocumentPart[]
+  ragSources: Array<SourceDocumentPart | SourceUrlPart>
   taskState: TaskState
   errorText: string
 }): { parts: MessagePart[]; preservedProgress: boolean } {

--- a/frontend/lib/api/agents.ts
+++ b/frontend/lib/api/agents.ts
@@ -584,7 +584,9 @@ export interface SSEContentDelta {
 }
 
 export interface SSERagContext {
+  query?: string
   contexts: Array<{
+    citation_id?: string
     kb_id: string
     kb_name: string
     document_id: string

--- a/frontend/lib/utils/message-converter.test.ts
+++ b/frontend/lib/utils/message-converter.test.ts
@@ -161,6 +161,46 @@ describe('message converter', () => {
     ])
   })
 
+  it('restores citation sources from persisted Agentic tool results', () => {
+    const converted = convertBackendMessage(message({
+      content: 'Cited answer[[cite:web_result_1]]',
+      steps: [
+        {
+          id: 'assistant-step',
+          role: 'assistant',
+          tool_calls: [{ id: 'web-call', name: 'web_search', arguments: { query: 'latest' } }],
+          created_at: '2026-07-19T00:00:01.000Z',
+          round_index: 1,
+        },
+        {
+          id: 'tool-step',
+          role: 'tool',
+          content: JSON.stringify({
+            success: true,
+            results: [{
+              citation_id: 'web_result_1',
+              title: 'Latest result',
+              url: 'https://example.test/latest',
+              content: 'Current information',
+            }],
+          }),
+          tool_call_id: 'web-call',
+          tool_name: 'web_search',
+          created_at: '2026-07-19T00:00:02.000Z',
+          round_index: 2,
+        },
+      ],
+    }))
+
+    expect(converted?.parts).toContainEqual({
+      type: 'source-url',
+      sourceId: 'web_result_1',
+      title: 'Latest result',
+      url: 'https://example.test/latest',
+      snippet: 'Current information',
+    })
+  })
+
   it('reconstructs multiple persisted iterations and keeps the final answer last', () => {
     const converted = convertBackendMessage(message({
       content: 'Final answer',

--- a/frontend/lib/utils/message-converter.ts
+++ b/frontend/lib/utils/message-converter.ts
@@ -12,11 +12,14 @@ import type {
   ReasoningPart,
   ToolCallPart,
   ToolResultPart,
+  TaskPart,
   SourceDocumentPart,
+  SourceUrlPart,
 } from '@/components/chat'
 import { isSourcePart } from '@/components/chat'
 import {
   inferToolResultIsError,
+  extractToolCitationSources,
   parseToolResultOutput,
   shouldDisplayMediaResultInBody,
 } from '@/lib/utils/tool-result'
@@ -73,6 +76,7 @@ export interface BackendMessage {
   reasoning_content?: string | null
   // RAG context
   rag_context?: Array<{
+    citation_id?: string
     document_id: string
     document_name: string
     content: string
@@ -186,6 +190,38 @@ function buildAssistantStepParts(step: BackendMessageStep, durationMs?: number):
 
   return parts
 }
+function appendToolResultCitations(parts: MessagePart[]): MessagePart[] {
+  const knownSourceIds = new Set(
+    parts.filter(isSourcePart).map((part) => part.sourceId).filter(Boolean)
+  )
+  const citationParts: Array<SourceUrlPart | SourceDocumentPart> = []
+  for (const part of parts) {
+    if (part.type !== 'tool-result') continue
+    for (const source of extractToolCitationSources(part.toolName, part.output)) {
+      if (knownSourceIds.has(source.citationId)) continue
+      knownSourceIds.add(source.citationId)
+      if (source.type === 'url' && source.url) {
+        citationParts.push({
+          type: 'source-url',
+          sourceId: source.citationId,
+          url: source.url,
+          title: source.title,
+          snippet: source.content,
+        })
+      } else if (source.type === 'document') {
+        citationParts.push({
+          type: 'source-document',
+          sourceId: source.citationId,
+          documentId: source.documentId,
+          documentName: source.title,
+          content: source.content || '',
+          metadata: source.metadata,
+        })
+      }
+    }
+  }
+  return citationParts.length > 0 ? [...parts, ...citationParts] : parts
+}
 
 /**
  * Convert a backend Message to a frontend ChatMessage
@@ -210,7 +246,7 @@ export function convertBackendMessage(message: BackendMessage): ChatMessage | nu
     return null
   }
 
-  const parts: MessagePart[] = []
+  let parts: MessagePart[] = []
 
   if (message.role === 'user') {
     // User message: text + images + files
@@ -355,6 +391,9 @@ export function convertBackendMessage(message: BackendMessage): ChatMessage | nu
       }
     }
   }
+  if (message.role === 'assistant') {
+    parts = appendToolResultCitations(parts)
+  }
 
   let finalParts = parts
   if (message.role === 'assistant' && message.round_status === 'max_iterations_reached') {
@@ -442,9 +481,9 @@ export function convertBackendMessages(messages: BackendMessage[]): ChatMessage[
     return result
   }
 
-  // Track RAG context from user messages to attach to the following assistant message
+  // Track RAG context and user query to attach to the following assistant message
   let pendingRagContext: BackendMessage['rag_context'] = null
-
+  let pendingRagQuery: string | undefined = undefined
   const aggregateRagContext = (
     contexts: BackendMessage['rag_context']
   ): BackendMessage['rag_context'] => {
@@ -490,8 +529,8 @@ export function convertBackendMessages(messages: BackendMessage[]): ChatMessage[
     // Capture RAG context from user messages
     if (message.role === 'user' && message.rag_context && Array.isArray(message.rag_context)) {
       pendingRagContext = aggregateRagContext(message.rag_context)
+      pendingRagQuery = message.content
     }
-
     const chatMessage = convertBackendMessage(message)
     if (!chatMessage) continue
 
@@ -541,7 +580,7 @@ export function convertBackendMessages(messages: BackendMessage[]): ChatMessage[
       if (pendingRagContext && pendingRagContext.length > 0) {
         const sources = pendingRagContext.map((ctx) => ({
           type: 'source-document',
-          sourceId: ctx.document_id,
+          sourceId: ctx.citation_id || ctx.document_id,
           documentId: ctx.document_id,
           documentName: ctx.document_name,
           content: ctx.content,
@@ -551,11 +590,32 @@ export function convertBackendMessages(messages: BackendMessage[]): ChatMessage[
             score: ctx.score,
           },
         } as SourceDocumentPart))
+        const ragTaskPart: TaskPart = {
+          type: 'task',
+          taskType: 'rag',
+          state: 'completed',
+          info: {
+            count: sources.length,
+            query: pendingRagQuery,
+            contexts: pendingRagContext,
+          },
+        }
+        const hasExistingRagTask = chatMessage.parts.some(
+          (part) => part.type === 'task' && (part as TaskPart).taskType === 'rag'
+        )
         const nonSourceParts = chatMessage.parts.filter((part) => !isSourcePart(part))
         const existingSources = chatMessage.parts.filter(isSourcePart)
-        chatMessage.parts = [...nonSourceParts, ...existingSources, ...sources]
+        chatMessage.parts = [
+          ...(hasExistingRagTask ? [] : [ragTaskPart]),
+          ...nonSourceParts,
+          ...existingSources,
+          ...sources,
+        ]
         pendingRagContext = null
+        pendingRagQuery = undefined
       }
+
+      chatMessage.parts = appendToolResultCitations(chatMessage.parts)
     }
 
     result.push(chatMessage)

--- a/frontend/lib/utils/message-converter.ts
+++ b/frontend/lib/utils/message-converter.ts
@@ -605,11 +605,13 @@ export function convertBackendMessages(messages: BackendMessage[]): ChatMessage[
         )
         const nonSourceParts = chatMessage.parts.filter((part) => !isSourcePart(part))
         const existingSources = chatMessage.parts.filter(isSourcePart)
+        const existingSourceIds = new Set(existingSources.map((s) => s.sourceId).filter(Boolean))
+        const deduplicatedSources = sources.filter((s) => !s.sourceId || !existingSourceIds.has(s.sourceId))
         chatMessage.parts = [
           ...(hasExistingRagTask ? [] : [ragTaskPart]),
           ...nonSourceParts,
           ...existingSources,
-          ...sources,
+          ...deduplicatedSources,
         ]
         pendingRagContext = null
         pendingRagQuery = undefined

--- a/frontend/lib/utils/tool-result.test.ts
+++ b/frontend/lib/utils/tool-result.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import {
+  extractToolCitationSources,
   getImageAssetUrl,
   getVideoAssetUrl,
   inferToolResultIsError,
@@ -21,6 +22,101 @@ describe('parseToolResultOutput', () => {
   it('preserves malformed and empty string output', () => {
     expect(parseToolResultOutput('')).toBe('')
     expect(parseToolResultOutput('{invalid')).toBe('{invalid')
+  })
+})
+
+describe('extractToolCitationSources', () => {
+  it('extracts structured sources from Agentic RAG and web search results', () => {
+    expect(extractToolCitationSources('knowledge_search', {
+      contexts: [{
+        citation_id: 'rag_a1',
+        document_id: 'doc-1',
+        document_name: 'Guide',
+        content: 'Policy text',
+        kb_id: 'kb-1',
+        score: 0.9,
+      }],
+    })).toEqual([expect.objectContaining({
+      type: 'document',
+      citationId: 'rag_a1',
+      documentId: 'doc-1',
+      title: 'Guide',
+      content: 'Policy text',
+    })])
+    expect(extractToolCitationSources('web_search', JSON.stringify({
+      results: [{
+        citation_id: 'web_b2',
+        title: 'News',
+        url: 'https://example.test/news',
+        content: 'Latest update',
+      }],
+    }))).toEqual([{
+      type: 'url',
+      citationId: 'web_b2',
+      title: 'News',
+      url: 'https://example.test/news',
+      content: 'Latest update',
+    }])
+  })
+
+  it('extracts sources from fetched webpages and attachment content tools', () => {
+    expect(extractToolCitationSources('fetch_webpage', {
+      citation_id: 'web_page_1',
+      url: 'https://example.test/page',
+      title: '  Page Title  ',
+      content: 'Page body',
+      success: true,
+    })).toEqual([{
+      type: 'url',
+      citationId: 'web_page_1',
+      title: 'Page Title',
+      url: 'https://example.test/page',
+      content: 'Page body',
+    }])
+    expect(extractToolCitationSources('fetch_webpage', {
+      citation_id: 'web_page_2',
+      url: 'https://example.test/page2',
+      title: '   ',
+      content: 'Page body 2',
+      success: true,
+    })).toEqual([{
+      type: 'url',
+      citationId: 'web_page_2',
+      url: 'https://example.test/page2',
+      content: 'Page body 2',
+    }])
+    expect(extractToolCitationSources('parse_asset', JSON.stringify({
+      citation_id: 'asset_doc_1',
+      ref: 'a1b2',
+      filename: 'report.pdf',
+      content: 'Parsed report',
+      truncated: false,
+    }))).toEqual([{
+      type: 'document',
+      citationId: 'asset_doc_1',
+      documentId: 'a1b2',
+      title: 'report.pdf',
+      content: 'Parsed report',
+      metadata: { ref: 'a1b2', truncated: false },
+    }])
+    expect(extractToolCitationSources('read_asset', {
+      citation_id: 'asset_text_1',
+      ref: 'c3d4',
+      filename: 'notes.txt',
+      content: 'Notes',
+    })).toEqual([expect.objectContaining({
+      type: 'document',
+      citationId: 'asset_text_1',
+      documentId: 'c3d4',
+      title: 'notes.txt',
+      content: 'Notes',
+    })])
+  })
+
+  it('ignores unrelated, malformed, and uncited tool results', () => {
+    expect(extractToolCitationSources('calculator', { results: [] })).toEqual([])
+    expect(extractToolCitationSources('knowledge_search', { contexts: [{}] })).toEqual([])
+    expect(extractToolCitationSources('web_search', '{invalid')).toEqual([])
   })
 })
 

--- a/frontend/lib/utils/tool-result.ts
+++ b/frontend/lib/utils/tool-result.ts
@@ -1,3 +1,13 @@
+export interface ToolCitationSource {
+  type: 'document' | 'url'
+  citationId: string
+  title?: string
+  content?: string
+  url?: string
+  documentId?: string
+  metadata?: Record<string, unknown>
+}
+
 export interface MediaAsset {
   url?: string | null
   base64?: string | null
@@ -52,6 +62,75 @@ export function parseToolResultOutput(output: unknown): unknown {
   } catch {
     return output
   }
+}
+
+export function extractToolCitationSources(
+  toolName: string,
+  output: unknown
+): ToolCitationSource[] {
+  const parsed = parseToolResultOutput(output)
+  if (!parsed || typeof parsed !== 'object') return []
+
+  if (toolName === 'knowledge_search' || toolName === 'search_knowledge_base') {
+    if (!('contexts' in parsed) || !Array.isArray(parsed.contexts)) return []
+    return parsed.contexts.flatMap((context) => {
+      if (!context || typeof context !== 'object' || !('citation_id' in context) || typeof context.citation_id !== 'string') return []
+      return [{
+        type: 'document' as const,
+        citationId: context.citation_id,
+        title: 'document_name' in context && typeof context.document_name === 'string' ? context.document_name : undefined,
+        content: 'content' in context && typeof context.content === 'string' ? context.content : undefined,
+        documentId: 'document_id' in context && typeof context.document_id === 'string' ? context.document_id : undefined,
+        metadata: {
+          kb_id: 'kb_id' in context ? context.kb_id : undefined,
+          kb_name: 'kb_name' in context ? context.kb_name : undefined,
+          score: 'score' in context ? context.score : undefined,
+        },
+      }]
+    })
+  }
+
+  if (toolName === 'web_search') {
+    if (!('results' in parsed) || !Array.isArray(parsed.results)) return []
+    return parsed.results.flatMap((result) => {
+      if (!result || typeof result !== 'object' || !('citation_id' in result) || typeof result.citation_id !== 'string') return []
+      return [{
+        type: 'url' as const,
+        citationId: result.citation_id,
+        title: 'title' in result && typeof result.title === 'string' && result.title.trim().length > 0 ? result.title.trim() : undefined,
+        content: 'content' in result && typeof result.content === 'string' ? result.content : undefined,
+        url: 'url' in result && typeof result.url === 'string' ? result.url : undefined,
+      }]
+    })
+  }
+  if (toolName === 'fetch_webpage') {
+    if (!('citation_id' in parsed) || typeof parsed.citation_id !== 'string') return []
+    return [{
+      type: 'url',
+      citationId: parsed.citation_id,
+      title: 'title' in parsed && typeof parsed.title === 'string' && parsed.title.trim().length > 0 ? parsed.title.trim() : undefined,
+      content: 'content' in parsed && typeof parsed.content === 'string' ? parsed.content : undefined,
+      url: 'url' in parsed && typeof parsed.url === 'string' ? parsed.url : undefined,
+    }]
+  }
+
+  if (toolName === 'read_asset' || toolName === 'parse_asset') {
+    if (!('citation_id' in parsed) || typeof parsed.citation_id !== 'string') return []
+    return [{
+      type: 'document',
+      citationId: parsed.citation_id,
+      title: 'filename' in parsed && typeof parsed.filename === 'string' ? parsed.filename : undefined,
+      content: 'content' in parsed && typeof parsed.content === 'string' ? parsed.content : undefined,
+      documentId: 'ref' in parsed && typeof parsed.ref === 'string' ? parsed.ref : undefined,
+      metadata: {
+        ref: 'ref' in parsed ? parsed.ref : undefined,
+        truncated: 'truncated' in parsed ? parsed.truncated : undefined,
+      },
+    }]
+  }
+
+
+  return []
 }
 
 export function inferToolResultIsError(output: unknown): boolean {


### PR DESCRIPTION
## Summary of Changes

### 1. Source Citations Infrastructure & Inline Citation Cards
- **Backend**:
  - Introduce `app.services.citations` to attach stable, deterministic `citation_id` across AUTO RAG, Agentic RAG, web search (`tavily`), and asset parser tools.
  - Automatically inject source citation guidance (`[[cite:SOURCE_ID]]`) into system prompts for agents with RAG, web search, or asset inspection capabilities.
  - Standardize prompt instructions and enhance robustness by accepting `cite:`, `citation:`, and `citation_id:` prefixes.
- **Frontend**:
  - Parse inline citation markers (`[[cite:...]]`, `[[citation:...]]`, `[[citation_id:...]]`) and render interactive hover cards (`<InlineCitation>`).
  - Add responsive boundaries to citation cards (`w-[min(calc(100vw-2rem),24rem)]`, `max-h-80`, `overflow-y-auto`) to prevent viewport overflows with long titles or URLs.

### 2. Multi-Round Chain of Thought Streaming State
- Decouple `hasTextContent` from `isChainOfThoughtStreaming`.
- Keep the Chain of Thought rotating loader and dynamic title (`Searching web...`, `Executing command...`) actively updating across subsequent tool iterations rather than prematurely freezing on the initial reasoning step.

### 3. Expandable Thought Process Step for Naive RAG
- Include the retrieval query in `rag_context` SSE events and persist retrieved chunk details.
- Upgrade Naive RAG in the Chain of Thought from a static text line into an expandable `<Tool>` card with:
  - **Parameters**: Search query passed to retrieval.
  - **Results**: Detailed chunk list with document name, knowledge base, score, and content snippet for easy debugging.

## Verification
- Pre-commit hooks passed: `ruff check`, `ruff format`, `eslint` (`--max-warnings=0`).
- Frontend unit tests and TypeScript: 80 tests passed across `message.test.tsx`, `message-converter.test.ts`, `inline-citation.test.tsx`, `tool-result.test.ts`, `tsc --noEmit` 0 errors.
- Backend tests: pytest passed across affected agent run worker, chat RAG, and system prompt suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stable source citations across knowledge search, web search, webpage fetching, and asset tools.
  - Chat responses now display inline citations and source cards using citation IDs, titles, URLs, and document details.
  - Citation sources are restored from tool results and persisted conversations.

- **Improvements**
  - Updated citation guidance for supported chat modes and source-enabled agents.
  - Improved source title fallbacks and citation card readability.
  - Conversation actions now appear smoothly when hovering over running-status indicators.
  - Chain-of-thought controls provide clearer hover and keyboard-focus feedback.

- **Bug Fixes**
  - Prevented unrelated or uncited sources from appearing in responses.
  - Improved citation handling during streaming and multi-step tool interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->