### PR TITLE
fix(chat): resume background streams after conversation switch

### DIFF
--- a/frontend/app/(chat)/chat/[id]/page.test.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.test.tsx
@@ -552,6 +552,35 @@ describe('PublicChatPage', () => {
     expect(disconnect).toHaveBeenCalled()
     renderer = undefined
   })
+  test('does not append an assistant loading placeholder when switching to a conversation with completed reasoning or tool output', async () => {
+    getConversations.mockResolvedValueOnce({
+      items: [
+        { id: 'conv-1', title: 'Chat 1' },
+        { id: 'conv-2', title: 'Chat 2' },
+      ],
+      total: 2,
+    })
+    getStoredRunSnapshot.mockImplementation((agentId: string, conversationId: string) => (
+      agentId === 'agent-1' && conversationId === 'conv-2' ? { runId: 'run-completed', lastSequence: 0 } : null
+    ))
+    convertBackendMessages.mockImplementationOnce(() => [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'solve problem' }] },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'reasoning', text: 'done thought', state: 'done' }] },
+    ])
+    getConversation.mockResolvedValueOnce({
+      messages: ['raw backend messages'],
+    })
+    render()
+    await flush()
+
+    const chat2 = renderer!.root.findAllByType('div').find((node) => nodeText(node).includes('Chat 2') && node.props.onClick)!
+    await act(async () => chat2.props.onClick())
+
+    expect(setMessages).toHaveBeenCalledWith([
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'solve problem' }] },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'reasoning', text: 'done thought', state: 'done' }] },
+    ])
+  })
   test('does not carry generated image references into another conversation', async () => {
     getPublicAgent.mockResolvedValueOnce({ ...agent, enable_attachments: true })
     render()

--- a/frontend/app/(chat)/chat/[id]/page.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.tsx
@@ -503,10 +503,22 @@ export default function PublicChatPage({
       // awaits getRunStatus — preventing a blank-message flash.
       const snapshot = resolvedParams ? getStoredRunSnapshot(resolvedParams.id, conv.id) : null
       const lastMsg = chatMessages[chatMessages.length - 1]
-      const needsPlaceholder = Boolean(
-        snapshot
-        && (!lastMsg || lastMsg.role !== 'assistant' || !lastMsg.parts.some(p => p.type === 'text' && (p as { text?: string }).text))
+      const hasCompletedAssistantContent = Boolean(
+        lastMsg
+        && lastMsg.role === 'assistant'
+        && (
+          lastMsg.parts.some((p) => {
+            if (p.type === 'text') return Boolean(p.text && p.text.trim().length > 0)
+            if (p.type === 'reasoning') return Boolean(p.text && p.text.trim().length > 0)
+            if (p.type === 'tool-call' || p.type === 'mcp-tool-call') return true
+            if (p.type === 'tool-result' || p.type === 'mcp-tool-result') return true
+            return false
+          })
+          || lastMsg.metadata?.isError
+          || lastMsg.metadata?.isManuallyStopped
+        )
       )
+      const needsPlaceholder = Boolean(snapshot && !hasCompletedAssistantContent)
       const loadingMessages = needsPlaceholder
         ? [...chatMessages, { id: `assistant-run-${snapshot!.runId}`, role: 'assistant' as const, parts: [], createdAt: new Date(), metadata: { isLoading: true } }]
         : chatMessages

--- a/frontend/components/chat/message.test.tsx
+++ b/frontend/components/chat/message.test.tsx
@@ -220,6 +220,18 @@ describe('message rendering', () => {
     expect(html).toContain('2/3')
     expect(html).toContain('chat.message.edit')
   })
+  test('preserves line breaks in user message text', () => {
+    const container = render(<Message
+      message={{
+        id: 'user-multiline',
+        role: 'user',
+        parts: [{ type: 'text', text: 'First line\nSecond line\nThird line' }],
+      }}
+    />)
+
+    const text = container.querySelector('.whitespace-pre-wrap')
+    expect(text?.textContent).toBe('First line\nSecond line\nThird line')
+  })
   test('opens a document attachment through the chat preview callback', () => {
     const onOpenCodePreview = mock(() => {})
     const container = render(<Message

--- a/frontend/components/chat/message.test.tsx
+++ b/frontend/components/chat/message.test.tsx
@@ -221,16 +221,17 @@ describe('message rendering', () => {
     expect(html).toContain('chat.message.edit')
   })
   test('preserves line breaks in user message text', () => {
+    const rawText = 'First line\nSecond line\nThird line\n**literal** [[cite:source-1]]'
     const container = render(<Message
       message={{
         id: 'user-multiline',
         role: 'user',
-        parts: [{ type: 'text', text: 'First line\nSecond line\nThird line' }],
+        parts: [{ type: 'text', text: rawText }],
       }}
     />)
 
     const text = container.querySelector('.whitespace-pre-wrap')
-    expect(text?.textContent).toBe('First line\nSecond line\nThird line')
+    expect(text?.textContent).toBe(rawText)
   })
   test('opens a document attachment through the chat preview callback', () => {
     const onOpenCodePreview = mock(() => {})

--- a/frontend/components/chat/message.tsx
+++ b/frontend/components/chat/message.tsx
@@ -866,6 +866,13 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
         if (hasIterationCapMarker && part.text.trim() === iterationCapLabel) {
           return null
         }
+        if (isUser) {
+          return (
+            <div key={index} className="whitespace-pre-wrap break-words">
+              {part.text}
+            </div>
+          )
+        }
         return (
           <TextWithCitations
             key={index}
@@ -1026,6 +1033,7 @@ const MessageComponent = React.forwardRef<HTMLDivElement, MessageProps>(
       hideReasoning,
       hideToolCalls,
       isStreaming,
+      isUser,
       iterationCapLabel,
       onOpenCodePreview,
       openLightbox,

--- a/frontend/hooks/use-chat.test.ts
+++ b/frontend/hooks/use-chat.test.ts
@@ -37,13 +37,14 @@ const getMessageVersions = mock(() => Promise.resolve<Array<{ id: string }>>([])
 const switchMessageVersion = mock(() => Promise.resolve())
 const getRunStatus = mock(() => Promise.resolve())
 const getRunEvents = mock(() => Promise.resolve([]))
+const streamRun = mock(() => ({ stream: Promise.resolve(new Response()), abort: mock() }))
 const postRunInput = mock(() => Promise.resolve())
 const postRunAnswer = mock(() => Promise.resolve({ status: 'queued' }))
 const stopRun = mock(() => Promise.resolve())
 const agentsApi = {
   chatStream,
   startRun: undefined,
-  streamRun: undefined,
+  streamRun,
   editMessageStream,
   regenerateStream,
   getConversation,
@@ -477,6 +478,57 @@ describe('useChat', () => {
       const assistantMessages = result.messages.filter((message) => message.role === 'assistant')
       expect(assistantMessages).toHaveLength(1)
       expect(assistantMessages[0].id).toBe('assistant-run-run-1')
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: originalWindow,
+      })
+    }
+  })
+  it('continues streaming incoming events on reconnected session', async () => {
+    const storage = new Map<string, string>([
+      ['clouisle:agent-run:agent-1:conversation-1', JSON.stringify({ runId: 'run-1', lastSequence: 0 })],
+    ])
+    const originalWindow = globalThis.window
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        sessionStorage: {
+          getItem: (key: string) => storage.get(key) ?? null,
+          setItem: (key: string, value: string) => storage.set(key, value),
+          removeItem: (key: string) => storage.delete(key),
+        },
+      },
+    })
+    try {
+      getRunStatus.mockResolvedValue({
+        id: 'run-1',
+        agent_id: 'agent-1',
+        conversation_id: 'conversation-1',
+        mode: 'send',
+        status: 'running',
+        canonical_message_id: 'canonical-msg-1',
+      })
+      const initialMessages = [
+        { id: 'u1', role: 'user' as const, parts: [{ type: 'text' as const, text: 'hello' }] },
+        { id: 'canonical-msg-1', role: 'assistant' as const, parts: [{ type: 'text' as const, text: 'Initial ' }], metadata: { isLoading: true } },
+      ]
+      streamRun.mockImplementation(() => ({
+        stream: Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+        } as unknown as Response),
+        abort: mock(() => {}),
+      }))
+      options = { agentId: 'agent-1', conversationId: 'conversation-1', initialMessages }
+      stateSlots = []
+      refSlots = []
+      renderHookHarness()
+      result.reconnect()
+      for (let i = 0; i < 5; i += 1) await flush()
+
+      expect(streamRun).toHaveBeenCalledWith('agent-1', 'run-1', 0)
     } finally {
       Object.defineProperty(globalThis, 'window', {
         configurable: true,

--- a/frontend/hooks/use-chat.test.ts
+++ b/frontend/hooks/use-chat.test.ts
@@ -178,10 +178,12 @@ beforeEach(() => {
     switchMessageVersion,
     getRunStatus,
     getRunEvents,
+    streamRun,
     postRunInput,
     postRunAnswer,
     stopRun,
   ]) apiMock.mockReset()
+
   getConversation.mockResolvedValue({ messages: [] })
   getMessageVersions.mockResolvedValue([])
   switchMessageVersion.mockResolvedValue()
@@ -479,6 +481,8 @@ describe('useChat', () => {
       expect(assistantMessages).toHaveLength(1)
       expect(assistantMessages[0].id).toBe('assistant-run-run-1')
     } finally {
+      result.reset()
+
       Object.defineProperty(globalThis, 'window', {
         configurable: true,
         value: originalWindow,
@@ -530,6 +534,78 @@ describe('useChat', () => {
 
       expect(streamRun).toHaveBeenCalledWith('agent-1', 'run-1', 0)
     } finally {
+      result.reset()
+
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: originalWindow,
+      })
+    }
+  })
+  it('ignores a terminal history reload after switching conversations', async () => {
+    const storage = new Map<string, string>([
+      ['clouisle:agent-run:agent-1:conversation-1', JSON.stringify({ runId: 'run-1', lastSequence: 0 })],
+    ])
+    const originalWindow = globalThis.window
+    const reload = deferred<{ messages: ChatMessage[] }>()
+    const reloadStarted = deferred<void>()
+    const staleMessages = [{ id: 'stale-assistant', role: 'assistant' as const, parts: [{ type: 'text' as const, text: 'stale' }] }]
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        sessionStorage: {
+          getItem: (key: string) => storage.get(key) ?? null,
+          setItem: (key: string, value: string) => storage.set(key, value),
+          removeItem: (key: string) => storage.delete(key),
+        },
+      },
+    })
+    try {
+      getRunStatus.mockResolvedValue({
+        id: 'run-1',
+        agent_id: 'agent-1',
+        conversation_id: 'conversation-1',
+        mode: 'send',
+        status: 'running',
+        canonical_message_id: 'canonical-msg-1',
+      })
+      getConversation.mockImplementation((conversationId: string) => {
+        if (conversationId === 'conversation-1') {
+          reloadStarted.resolve()
+          return reload.promise
+        }
+        return Promise.resolve({ messages: [] })
+      })
+      streamRun.mockImplementation(() => ({
+        stream: Promise.resolve(new Response()),
+        abort: mock(() => {}),
+      }))
+      streamEvents = [{ event: 'run_end', data: { status: 'completed' } }]
+      options = {
+        agentId: 'agent-1',
+        conversationId: 'conversation-1',
+        initialMessages: [
+          { id: 'u-current', role: 'user' as const, parts: [{ type: 'text' as const, text: 'current' }] },
+          { id: 'canonical-msg-1', role: 'assistant' as const, parts: [], metadata: { isLoading: true } },
+        ],
+      }
+      stateSlots = []
+      refSlots = []
+      renderHookHarness()
+      result.reconnect()
+      await reloadStarted.promise
+
+      result.setConversationId('conversation-2')
+      await flush()
+      reload.resolve({ messages: staleMessages })
+      await flush()
+      renderHookHarness()
+
+      expect(result.conversationId).toBe('conversation-2')
+      expect(result.messages).not.toEqual(staleMessages)
+      expect(result.messages[0]?.id).toBe('u-current')
+    } finally {
+      result.reset()
       Object.defineProperty(globalThis, 'window', {
         configurable: true,
         value: originalWindow,

--- a/frontend/hooks/use-chat.test.ts
+++ b/frontend/hooks/use-chat.test.ts
@@ -438,6 +438,52 @@ describe('useChat', () => {
       })
     }
   })
+  it('reuses an existing trailing loading placeholder message instead of appending a duplicate', async () => {
+    const storage = new Map<string, string>([
+      ['clouisle:agent-run:agent-1:conversation-1', JSON.stringify({ runId: 'run-1', lastSequence: 0 })],
+    ])
+    const originalWindow = globalThis.window
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        sessionStorage: {
+          getItem: (key: string) => storage.get(key) ?? null,
+          setItem: (key: string, value: string) => storage.set(key, value),
+          removeItem: (key: string) => storage.delete(key),
+        },
+      },
+    })
+    try {
+      getRunStatus.mockResolvedValue({
+        id: 'run-1',
+        agent_id: 'agent-1',
+        conversation_id: 'conversation-1',
+        mode: 'send',
+        status: 'running',
+        canonical_message_id: 'canonical-msg-1',
+      })
+      const initialMessages = [
+        { id: 'u1', role: 'user' as const, parts: [{ type: 'text' as const, text: 'hello' }] },
+        { id: 'assistant-run-run-1', role: 'assistant' as const, parts: [], metadata: { isLoading: true } },
+      ]
+      options = { agentId: 'agent-1', conversationId: 'conversation-1', initialMessages }
+      stateSlots = []
+      refSlots = []
+      renderHookHarness()
+      result.reconnect()
+      for (let i = 0; i < 5; i += 1) await flush()
+
+      renderHookHarness()
+      const assistantMessages = result.messages.filter((message) => message.role === 'assistant')
+      expect(assistantMessages).toHaveLength(1)
+      expect(assistantMessages[0].id).toBe('assistant-run-run-1')
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: originalWindow,
+      })
+    }
+  })
   it('ignores a stale run-status response after switching conversations', async () => {
     const storage = new Map<string, string>([
       ['clouisle:agent-run:agent-1:conversation-a', JSON.stringify({ runId: 'run-a', lastSequence: 2 })],

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -386,18 +386,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
   }, [renderSession])
 
   const ensureSession = useCallback((messageId: string | null, runIdForSession?: string) => {
-    if (runIdForSession) {
-      const existing = sessionsByRunRef.current.get(runIdForSession)
-      if (existing) {
-        activeSessionRef.current = existing
-        return existing
-      }
-    }
-
-    if (!messageId) return null
-    const existingMessage = messagesRef.current.find((message) => message.id === messageId)
-    // If no exact ID match, check if there is an unattached placeholder message
-    // (e.g. `assistant-run-${runId}`) at the tail we can adopt.
+    const existingMessage = messageId ? messagesRef.current.find((message) => message.id === messageId) : undefined
     const lastMessage = messagesRef.current[messagesRef.current.length - 1]
     const adoptablePlaceholderId = !existingMessage
       && runIdForSession
@@ -409,11 +398,33 @@ export function useChat(options: UseChatOptions): UseChatReturn {
     const adoptedMessage = adoptablePlaceholderId ? lastMessage : existingMessage
     const effectiveDisplayId = adoptablePlaceholderId ?? messageId
 
+    if (runIdForSession) {
+      const existing = sessionsByRunRef.current.get(runIdForSession)
+      if (existing) {
+        existing.reloadAfterTerminal = true
+        if (effectiveDisplayId && existing.displayMessageId !== effectiveDisplayId) {
+          existing.displayMessageId = effectiveDisplayId
+        }
+        if (messageId && existing.backendMessageId !== messageId) {
+          existing.backendMessageId = messageId
+        }
+        if (adoptedMessage && existing.state.segments.length === 0 && adoptedMessage.parts.length > 0) {
+          existing.state = createAssistantStreamStateFromParts(adoptedMessage.parts)
+        }
+        activeSessionRef.current = existing
+        syncStreamingState(existing)
+        return existing
+      }
+    }
+
+    if (!effectiveDisplayId) return null
+
     const session: AssistantStreamSession = {
       mode: 'reconnect',
       displayMessageId: effectiveDisplayId,
       backendMessageId: messageId,
       keepDisplayIdOnStart: Boolean(adoptablePlaceholderId),
+      reloadAfterTerminal: true,
       state: adoptedMessage ? createAssistantStreamStateFromParts(adoptedMessage.parts) : createAssistantStreamState(),
       versionNumber: adoptedMessage?.versionNumber ?? 1,
       versionCount: adoptedMessage?.versionCount ?? 1,
@@ -2108,8 +2119,20 @@ function applyAssistantStreamEvent(
 
     case 'reasoning_delta': {
       const data = event.data as { delta: string }
-      const block = state.reasoningBlocks[state.currentReasoningIndex]
-      if (!block) return false
+      let block = state.reasoningBlocks[state.currentReasoningIndex]
+      if (!block) {
+        const startTime = Date.now()
+        const reasoningIndex = state.reasoningBlocks.push({ text: '', startTime, state: 'streaming' }) - 1
+        state.currentReasoningIndex = reasoningIndex
+        state.segments.push({
+          type: 'reasoning',
+          reasoningIndex,
+          reasoningText: '',
+          reasoningState: 'streaming',
+          reasoningStartTime: startTime,
+        })
+        block = state.reasoningBlocks[reasoningIndex]
+      }
       block.text += data.delta
       const reasoningSegment = state.segments.find(
         segment => segment.type === 'reasoning' && segment.reasoningIndex === state.currentReasoningIndex

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -396,22 +396,36 @@ export function useChat(options: UseChatOptions): UseChatReturn {
 
     if (!messageId) return null
     const existingMessage = messagesRef.current.find((message) => message.id === messageId)
+    // If no exact ID match, check if there is an unattached placeholder message
+    // (e.g. `assistant-run-${runId}`) at the tail we can adopt.
+    const lastMessage = messagesRef.current[messagesRef.current.length - 1]
+    const adoptablePlaceholderId = !existingMessage
+      && runIdForSession
+      && lastMessage?.role === 'assistant'
+      && (lastMessage.id === `assistant-run-${runIdForSession}` || (lastMessage.metadata?.isLoading && lastMessage.parts.length === 0))
+      ? lastMessage.id
+      : null
+
+    const adoptedMessage = adoptablePlaceholderId ? lastMessage : existingMessage
+    const effectiveDisplayId = adoptablePlaceholderId ?? messageId
+
     const session: AssistantStreamSession = {
       mode: 'reconnect',
-      displayMessageId: messageId,
+      displayMessageId: effectiveDisplayId,
       backendMessageId: messageId,
-      state: existingMessage ? createAssistantStreamStateFromParts(existingMessage.parts) : createAssistantStreamState(),
-      versionNumber: existingMessage?.versionNumber ?? 1,
-      versionCount: existingMessage?.versionCount ?? 1,
+      keepDisplayIdOnStart: Boolean(adoptablePlaceholderId),
+      state: adoptedMessage ? createAssistantStreamStateFromParts(adoptedMessage.parts) : createAssistantStreamState(),
+      versionNumber: adoptedMessage?.versionNumber ?? 1,
+      versionCount: adoptedMessage?.versionCount ?? 1,
       receivedTerminalEvent: false,
       receivedMessageEnd: false,
       endNotified: false,
       runId: runIdForSession,
     }
     setMessages((previous) => {
-      if (!previous.some((message) => message.id === messageId)) {
+      if (!previous.some((message) => message.id === effectiveDisplayId)) {
         return [...previous, {
-          id: messageId,
+          id: effectiveDisplayId,
           role: 'assistant',
           parts: [],
           createdAt: new Date(),
@@ -419,7 +433,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
         }]
       }
       return previous.map((message) => (
-        message.id === messageId
+        message.id === effectiveDisplayId
           ? { ...message, metadata: { ...message.metadata, isLoading: true, isManuallyStopped: false } }
           : message
       ))

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -397,11 +397,13 @@ export function useChat(options: UseChatOptions): UseChatReturn {
 
     const adoptedMessage = adoptablePlaceholderId ? lastMessage : existingMessage
     const effectiveDisplayId = adoptablePlaceholderId ?? messageId
+    const sessionConversationId = activeRunConversationRef.current ?? conversationIdRef.current
 
     if (runIdForSession) {
       const existing = sessionsByRunRef.current.get(runIdForSession)
       if (existing) {
         existing.reloadAfterTerminal = true
+        if (sessionConversationId) existing.conversationId = sessionConversationId
         if (effectiveDisplayId && existing.displayMessageId !== effectiveDisplayId) {
           existing.displayMessageId = effectiveDisplayId
         }
@@ -432,6 +434,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       receivedMessageEnd: false,
       endNotified: false,
       runId: runIdForSession,
+      conversationId: sessionConversationId ?? undefined,
     }
     setMessages((previous) => {
       if (!previous.some((message) => message.id === effectiveDisplayId)) {
@@ -744,6 +747,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       if (!session) return
       const nextConversationId = startData.conversation_id
       if (nextConversationId) {
+        session.conversationId = nextConversationId
         activeRunConversationRef.current = nextConversationId
         if (conversationIdRef.current !== nextConversationId) {
           setConversationId(nextConversationId)
@@ -819,6 +823,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       const terminalStatus = data.status as AgentRunStatus | undefined
       const terminalSession = session ?? (eventMessageId ? ensureSession(eventMessageId, envelope?.run_id) : null)
       if (terminalSession) {
+        const terminalConversationId = terminalSession.conversationId
         if (terminalStatus === 'stopped') {
           markAssistantStopped(terminalSession)
         } else if (terminalStatus === 'failed') {
@@ -830,11 +835,15 @@ export function useChat(options: UseChatOptions): UseChatReturn {
         } else if (!terminalSession.receivedMessageEnd) {
           finishAssistantMessage(terminalSession)
         }
-        if (terminalSession.reloadAfterTerminal) {
-          void reloadConversationMessages().catch(() => undefined)
+        if (terminalSession.reloadAfterTerminal && terminalConversationId) {
+          void reloadConversationMessages(
+            terminalConversationId,
+            () => conversationIdRef.current === terminalConversationId,
+          ).catch(() => undefined)
         }
         notifyStreamEnd(terminalSession)
       }
+
       if (terminalStatus) setCurrentRunStatus(terminalStatus)
       const terminalRunId = envelope?.run_id ?? runIdRef.current
       if (terminalRunId) {
@@ -1178,6 +1187,15 @@ export function useChat(options: UseChatOptions): UseChatReturn {
     start: () => { stream: Promise<Response>; abort: () => void } | Promise<{ stream: Promise<Response>; abort: () => void }>,
     options: { reloadAfterTerminal?: boolean; reloadOnError?: boolean } = {}
   ) => {
+    const reloadTerminalConversation = async () => {
+      const terminalConversationId = session.conversationId
+      if (!terminalConversationId) return
+      await reloadConversationMessages(
+        terminalConversationId,
+        () => conversationIdRef.current === terminalConversationId,
+      )
+    }
+
     const epoch = ++connectionEpochRef.current
     try {
       const { stream, abort } = await start()
@@ -1204,7 +1222,8 @@ export function useChat(options: UseChatOptions): UseChatReturn {
         return
       }
       if (!session.receivedTerminalEvent) finishAssistantMessage(session)
-      if (options.reloadAfterTerminal) await reloadConversationMessages().catch(() => undefined)
+      if (options.reloadAfterTerminal) await reloadTerminalConversation().catch(() => undefined)
+
       setCurrentStatus('idle')
       notifyStreamEnd(session)
       resetStreamingState()
@@ -1218,7 +1237,8 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       const chatError: ChatError = { message: reason instanceof Error ? reason.message : '' }
       onError?.(chatError)
       markAssistantError(session, chatError)
-      if (options.reloadOnError) await reloadConversationMessages().catch(() => undefined)
+      if (options.reloadOnError) await reloadTerminalConversation().catch(() => undefined)
+
       setCurrentStatus('idle')
       notifyStreamEnd(session)
       resetStreamingState()
@@ -1284,6 +1304,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       receivedTerminalEvent: false,
       receivedMessageEnd: false,
       endNotified: false,
+      conversationId: conversationIdRef.current ?? undefined,
     }
     activeSessionRef.current = session
     syncStreamingState(session)
@@ -1304,6 +1325,8 @@ export function useChat(options: UseChatOptions): UseChatReturn {
         await consumeStream(session, async () => {
           const started = await api.startRun!(agentId, request)
           session.runId = started.run_id
+          session.conversationId = started.conversation_id
+
           reconcileOptimisticUserMessage(session, started.user_message_id)
           trackRun(started.run_id, started.conversation_id)
           storeRunSnapshot(started.conversation_id)
@@ -1494,6 +1517,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       receivedMessageEnd: false,
       endNotified: false,
       reloadAfterTerminal: true,
+      conversationId: conversationIdRef.current ?? undefined,
     }
     activeSessionRef.current = session
     syncStreamingState(session)
@@ -1548,6 +1572,7 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       receivedMessageEnd: false,
       endNotified: false,
       keepDisplayIdOnStart: true,
+      conversationId: conversationIdRef.current ?? undefined,
     }
     activeSessionRef.current = session
     await consumeStream(session, () => api.regenerateStream(agentId, messageId, variables))
@@ -1676,6 +1701,7 @@ interface AssistantStreamSession {
   keepDisplayIdOnStart?: boolean
   reloadAfterTerminal?: boolean
   runId?: string
+  conversationId?: string
 }
 
 interface PendingRunInput {


### PR DESCRIPTION
## Summary

- Preserve and restore assistant stream state when reconnecting to a background run after switching conversations.
- Reconcile canonical and display message IDs, and handle reasoning deltas received without a preceding reasoning-start event.
- Reload authoritative conversation history when a reconnect reaches a terminal event.
- Add regression coverage for continuing a reconnected stream.

## Verification

- `bun test hooks/use-chat.test.ts`
- `bun test app/(chat)/chat/[id]/page.test.tsx`
- `bun test components/chat/message.test.tsx`
- Pre-commit ESLint checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate loading indicators when reconnecting to an active conversation run.
  - Improved reconnection so ongoing responses continue streaming correctly.
  - Prevented loading placeholders from appearing when a conversation already contains completed reasoning or tool activity.
  - Preserved line breaks in multiline user messages.
  - Ensured reasoning updates display correctly when received during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->