### PR TITLE
fix: respect configured default message language

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 from app.core.config import settings
 from app.core.redis import is_token_blacklisted
 from app.core.timezone import now_utc
-from app.core.i18n import set_language
+from app.core.i18n import set_language, resolve_language
 from app.models.user import User, ScopedRoleAssignment
 from app.models.api_key import APIKey
 from app.schemas.token import TokenPayload
@@ -56,9 +56,9 @@ async def get_current_user_or_api_key(
         # 否则尝试 JWT 认证
         user = await _authenticate_jwt(auth_token)
 
-    # Set language from user's locale preference
-    if hasattr(user, "locale") and user.locale:
-        set_language(user.locale)
+    # Set language from user's locale preference if set, else system default
+    user_locale = getattr(user, "locale", None) if user else None
+    set_language(await resolve_language(user_locale))
 
     return user, api_key
 
@@ -195,9 +195,9 @@ async def get_current_active_user(
                 else "inactive_user"
             ),
         )
-    # Set language from user's locale preference
-    if hasattr(current_user, "locale") and current_user.locale:
-        set_language(current_user.locale)
+    # Set language from user's locale preference if set, else system default
+    user_locale = getattr(current_user, "locale", None) if current_user else None
+    set_language(await resolve_language(user_locale))
     return current_user
 
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -104,6 +104,8 @@ async def _authenticate_api_key(api_key_str: str) -> tuple[User, APIKey]:
             .prefetch_related("roles__permissions")
             .first()
         )
+    user_locale = getattr(user, "locale", None) if user else None
+    set_language(await resolve_language(user_locale))
 
     if not user or not user.is_active:
         raise BusinessError(
@@ -115,7 +117,6 @@ async def _authenticate_api_key(api_key_str: str) -> tuple[User, APIKey]:
             ),
             status_code=status.HTTP_401_UNAUTHORIZED,
         )
-
     # 更新最后使用时间
     matched_api_key.last_used_at = now_utc()
     await matched_api_key.save(update_fields=["last_used_at"])
@@ -164,6 +165,8 @@ async def _authenticate_jwt(token: str) -> User:
             status_code=status.HTTP_404_NOT_FOUND,
         )
 
+    user_locale = getattr(user, "locale", None) if user else None
+    set_language(await resolve_language(user_locale))
     # 检查单一会话模式
     from app.models.site_setting import SiteSetting
     from app.core.redis import get_user_session
@@ -186,6 +189,8 @@ async def _authenticate_jwt(token: str) -> User:
 async def get_current_active_user(
     current_user: User = Depends(get_current_user),
 ) -> User:
+    user_locale = getattr(current_user, "locale", None) if current_user else None
+    set_language(await resolve_language(user_locale))
     if not current_user.is_active:
         raise BusinessError(
             code=ResponseCode.INACTIVE_USER,
@@ -195,9 +200,6 @@ async def get_current_active_user(
                 else "inactive_user"
             ),
         )
-    # Set language from user's locale preference if set, else system default
-    user_locale = getattr(current_user, "locale", None) if current_user else None
-    set_language(await resolve_language(user_locale))
     return current_user
 
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -189,8 +189,6 @@ async def _authenticate_jwt(token: str) -> User:
 async def get_current_active_user(
     current_user: User = Depends(get_current_user),
 ) -> User:
-    user_locale = getattr(current_user, "locale", None) if current_user else None
-    set_language(await resolve_language(user_locale))
     if not current_user.is_active:
         raise BusinessError(
             code=ResponseCode.INACTIVE_USER,
@@ -200,6 +198,9 @@ async def get_current_active_user(
                 else "inactive_user"
             ),
         )
+    # Set language from user's locale preference if set, else system default
+    user_locale = getattr(current_user, "locale", None) if current_user else None
+    set_language(await resolve_language(user_locale))
     return current_user
 
 

--- a/backend/app/api/v1/admin/endpoints/agents.py
+++ b/backend/app/api/v1/admin/endpoints/agents.py
@@ -41,7 +41,7 @@ from app.schemas.response import (
 )
 from app.services.audit_log import AuditLogService
 from app.services.auto_notification import AutoNotificationService
-from app.core.i18n import t
+from app.core.i18n import t, get_default_language
 
 router = APIRouter()
 
@@ -535,11 +535,16 @@ async def publish_agent(
         metadata={"team_id": str(agent.team_id), "visibility": agent.visibility.value},
     )
     if agent.team_id:
+        default_lang = await get_default_language()
         await AutoNotificationService.send_to_team(
             notification_type=AutoNotificationType.AGENT_PUBLISHED,
             team_id=UUID(str(agent.team_id)),
-            title=t("notify_agent_published_title"),
-            content=t("notify_agent_published_content", agent_name=agent.name),
+            title=t("notify_agent_published_title", lang=default_lang),
+            content=t(
+                "notify_agent_published_content",
+                lang=default_lang,
+                agent_name=agent.name,
+            ),
         )
 
     return success(data=await build_agent_out(agent), msg_key="agent_published")
@@ -571,11 +576,16 @@ async def unpublish_agent(
         metadata={"team_id": str(agent.team_id), "visibility": agent.visibility.value},
     )
     if agent.team_id:
+        default_lang = await get_default_language()
         await AutoNotificationService.send_to_team(
             notification_type=AutoNotificationType.AGENT_UNPUBLISHED,
             team_id=UUID(str(agent.team_id)),
-            title=t("notify_agent_unpublished_title"),
-            content=t("notify_agent_unpublished_content", agent_name=agent.name),
+            title=t("notify_agent_unpublished_title", lang=default_lang),
+            content=t(
+                "notify_agent_unpublished_content",
+                lang=default_lang,
+                agent_name=agent.name,
+            ),
         )
 
     return success(data=await build_agent_out(agent), msg_key="agent_unpublished")

--- a/backend/app/api/v1/admin/endpoints/users.py
+++ b/backend/app/api/v1/admin/endpoints/users.py
@@ -8,7 +8,7 @@ from tortoise.expressions import Q
 
 from app.api import deps
 from app.core import security
-from app.core.i18n import t
+from app.core.i18n import t, resolve_language
 from app.core.password import validate_password
 from app.core.email import (
     send_email,
@@ -385,11 +385,12 @@ async def activate_user(
         ),
     )
 
+    user_locale = await resolve_language(getattr(user, "locale", None))
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.USER_ACTIVATED,
         user_id=user.id,
-        title=t("notify_user_activated_title", lang=user.locale),
-        content=t("notify_user_activated_content", lang=user.locale),
+        title=t("notify_user_activated_title", lang=user_locale),
+        content=t("notify_user_activated_content", lang=user_locale),
     )
 
     return success(
@@ -444,11 +445,12 @@ async def deactivate_user(
         ),
     )
 
+    user_locale = await resolve_language(getattr(user, "locale", None))
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.USER_DEACTIVATED,
         user_id=user.id,
-        title=t("notify_user_deactivated_title", lang=user.locale),
-        content=t("notify_user_deactivated_content", lang=user.locale),
+        title=t("notify_user_deactivated_title", lang=user_locale),
+        content=t("notify_user_deactivated_content", lang=user_locale),
     )
 
     return success(
@@ -535,11 +537,12 @@ async def update_user(
     )
 
     if password_changed:
+        user_locale = await resolve_language(getattr(user, "locale", None))
         await AutoNotificationService.send_to_user(
             notification_type=AutoNotificationType.USER_PASSWORD_RESET,
             user_id=user.id,
-            title=t("notify_user_password_reset_title", lang=user.locale),
-            content=t("notify_user_password_reset_content", lang=user.locale),
+            title=t("notify_user_password_reset_title", lang=user_locale),
+            content=t("notify_user_password_reset_content", lang=user_locale),
         )
 
     return success(
@@ -611,11 +614,12 @@ async def force_password_change(
     await user.save()
 
     # Send notification to user
+    user_locale = await resolve_language(getattr(user, "locale", None))
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.PASSWORD_FORCE_CHANGE,
         user_id=user.id,
-        title=t("notify_password_force_change_title", lang=user.locale),
-        content=t("notify_password_force_change_content", lang=user.locale),
+        title=t("notify_password_force_change_title", lang=user_locale),
+        content=t("notify_password_force_change_content", lang=user_locale),
         level=NotificationLevel.HIGH,
     )
 
@@ -777,11 +781,12 @@ async def bulk_force_password_change(
             audit_diffs.append({"user_id": str(user.id), **diff})
 
         # Send notification
+        user_locale = await resolve_language(getattr(user, "locale", None))
         await AutoNotificationService.send_to_user(
             notification_type=AutoNotificationType.PASSWORD_FORCE_CHANGE,
             user_id=user.id,
-            title=t("notify_password_force_change_title", lang=user.locale),
-            content=t("notify_password_force_change_content", lang=user.locale),
+            title=t("notify_password_force_change_title", lang=user_locale),
+            content=t("notify_password_force_change_content", lang=user_locale),
             level=NotificationLevel.HIGH,
         )
         success_count += 1

--- a/backend/app/api/v1/endpoints/agents.py
+++ b/backend/app/api/v1/endpoints/agents.py
@@ -52,7 +52,7 @@ from app.schemas.response import (
 from app.services.audit_log import AuditLogService
 from app.services.auto_notification import AutoNotificationService
 from app.models.notification import AutoNotificationType
-from app.core.i18n import t
+from app.core.i18n import t, get_default_language
 from app.core.timezone import now_utc
 from app.api.v1.endpoints.chat import build_message_round_payloads
 from app.services.message_branching import get_visible_conversation_messages
@@ -818,11 +818,16 @@ async def publish_agent(
 
     # 发送团队通知
     if agent.team_id:
+        default_lang = await get_default_language()
         await AutoNotificationService.send_to_team(
             notification_type=AutoNotificationType.AGENT_PUBLISHED,
             team_id=UUID(str(agent.team_id)),
-            title=t("notify_agent_published_title"),
-            content=t("notify_agent_published_content", agent_name=agent.name),
+            title=t("notify_agent_published_title", lang=default_lang),
+            content=t(
+                "notify_agent_published_content",
+                lang=default_lang,
+                agent_name=agent.name,
+            ),
         )
 
     agent_data = await build_agent_out(agent)
@@ -859,11 +864,16 @@ async def unpublish_agent(
 
     # 发送团队通知
     if agent.team_id:
+        default_lang = await get_default_language()
         await AutoNotificationService.send_to_team(
             notification_type=AutoNotificationType.AGENT_UNPUBLISHED,
             team_id=UUID(str(agent.team_id)),
-            title=t("notify_agent_unpublished_title"),
-            content=t("notify_agent_unpublished_content", agent_name=agent.name),
+            title=t("notify_agent_unpublished_title", lang=default_lang),
+            content=t(
+                "notify_agent_unpublished_content",
+                lang=default_lang,
+                agent_name=agent.name,
+            ),
         )
 
     agent_data = await build_agent_out(agent)

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -1914,12 +1914,13 @@ async def _enqueue_durable_chat_run(
         )
 
     await update_message_stats(agent, token_usage=None)
+    effective_locale = await resolve_language(getattr(current_user, "locale", None))
     streaming_config = get_streaming_config(agent)
     _, updated_file_urls = await build_file_content_for_context(
         agent=agent,
         file_urls=chat_in.file_urls,
         legacy_files=chat_in.files,
-        user_locale=await resolve_language(getattr(current_user, "locale", None)),
+        user_locale=effective_locale,
         tool_timeouts=streaming_config["tool_timeouts"],
         user=current_user,
     )
@@ -1963,7 +1964,7 @@ async def _enqueue_durable_chat_run(
         ),
         variables=chat_in.variables,
         branch_parent_id=user_branch_parent_id,
-        locale=await resolve_language(getattr(current_user, "locale", None)),
+        locale=effective_locale,
     )
     run.worker_payload = payload
     await run.save(update_fields=["worker_payload"])

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -23,7 +23,7 @@ from tortoise.expressions import F, Q
 from tortoise.transactions import in_transaction
 
 from app.api import deps
-from app.core.i18n import t
+from app.core.i18n import resolve_language, t
 from app.models.asset import MessageAsset
 from app.models.user import User, Team
 from app.models.model import TeamModel
@@ -662,7 +662,10 @@ def get_round_terminal_status(
 
 
 def build_max_iterations_terminal_content(user_locale: str | None = None) -> str:
-    return t("chat_max_iterations_reached", lang=user_locale)
+    from app.core.i18n import resolve_language_sync
+
+    effective_locale = resolve_language_sync(user_locale)
+    return t("chat_max_iterations_reached", lang=effective_locale)
 
 
 async def round_has_persisted_trace(message: Message | None) -> bool:
@@ -1801,7 +1804,7 @@ async def _enqueue_existing_message_run(
         canonical_message_id=canonical_message_id,
         in_place_retry=in_place_retry,
         branch_parent_id=branch_parent_id,
-        locale=current_user.locale,
+        locale=await resolve_language(getattr(current_user, "locale", None)),
         include_current_user_message=include_current_user_message,
         history_before_message_created_at=history_before_message_created_at,
         exclude_message_ids=exclude_message_ids,
@@ -1916,7 +1919,7 @@ async def _enqueue_durable_chat_run(
         agent=agent,
         file_urls=chat_in.file_urls,
         legacy_files=chat_in.files,
-        user_locale=current_user.locale,
+        user_locale=await resolve_language(getattr(current_user, "locale", None)),
         tool_timeouts=streaming_config["tool_timeouts"],
         user=current_user,
     )
@@ -1960,7 +1963,7 @@ async def _enqueue_durable_chat_run(
         ),
         variables=chat_in.variables,
         branch_parent_id=user_branch_parent_id,
-        locale=current_user.locale,
+        locale=await resolve_language(getattr(current_user, "locale", None)),
     )
     run.worker_payload = payload
     await run.save(update_fields=["worker_payload"])

--- a/backend/app/api/v1/endpoints/login.py
+++ b/backend/app/api/v1/endpoints/login.py
@@ -32,7 +32,7 @@ from app.core.email import (
 )
 from app.core.captcha import create_captcha_proof, generate_captcha, verify_captcha
 from app.core.timezone import now_utc
-from app.core.i18n import t, get_default_language, normalize_language
+from app.core.i18n import get_default_language, resolve_language, t
 from app.models.user import User
 from app.models.site_setting import SiteSetting
 from app.schemas.token import Token
@@ -211,13 +211,14 @@ async def login_access_token(
 
         if locked:
             # 发送账户锁定通知
+            user_locale = await resolve_language(getattr(user, "locale", None))
             await AutoNotificationService.send_to_user(
                 notification_type=AutoNotificationType.SECURITY_ACCOUNT_LOCKED,
                 user_id=user.id,
-                title=t("notify_account_locked_title", lang=user.locale),
+                title=t("notify_account_locked_title", lang=user_locale),
                 content=t(
                     "notify_account_locked_content",
-                    lang=user.locale,
+                    lang=user_locale,
                     lockout_minutes=(lockout_seconds or 0) // 60,
                 ),
                 level=NotificationLevel.HIGH,
@@ -315,13 +316,14 @@ async def login_access_token(
 
     # Send anomaly notification if detected
     if is_anomaly:
+        user_locale = await resolve_language(getattr(user, "locale", None))
         await AutoNotificationService.send_to_user(
             notification_type=AutoNotificationType.SECURITY_LOGIN_ANOMALY,
             user_id=user.id,
-            title=t("notify_login_anomaly_title", lang=user.locale),
+            title=t("notify_login_anomaly_title", lang=user_locale),
             content=t(
                 "notify_login_anomaly_content",
-                lang=user.locale,
+                lang=user_locale,
                 ip_address=anomaly_details.get("ip_address", "unknown"),
                 login_time=anomaly_details.get("login_time", ""),
                 user_agent=anomaly_details.get("user_agent", "Unknown")[:100],
@@ -545,13 +547,14 @@ async def verify_totp(
 
     # Send anomaly notification if detected
     if is_anomaly:
+        user_locale = await resolve_language(getattr(user, "locale", None))
         await AutoNotificationService.send_to_user(
             notification_type=AutoNotificationType.SECURITY_LOGIN_ANOMALY,
             user_id=user.id,
-            title=t("notify_login_anomaly_title", lang=user.locale),
+            title=t("notify_login_anomaly_title", lang=user_locale),
             content=t(
                 "notify_login_anomaly_content",
-                lang=user.locale,
+                lang=user_locale,
                 ip_address=anomaly_details.get("ip_address", "unknown"),
                 login_time=anomaly_details.get("login_time", ""),
                 user_agent=anomaly_details.get("user_agent", "Unknown")[:100],
@@ -761,7 +764,7 @@ async def register(
         "force_password_change_first_login", False
     )
 
-    registration_locale = normalize_language(user_in.locale)
+    registration_locale = await resolve_language(user_in.locale)
 
     # Create user
     hashed_password = security.get_password_hash(user_in.password)

--- a/backend/app/api/v1/endpoints/login.py
+++ b/backend/app/api/v1/endpoints/login.py
@@ -32,7 +32,7 @@ from app.core.email import (
 )
 from app.core.captcha import create_captcha_proof, generate_captcha, verify_captcha
 from app.core.timezone import now_utc
-from app.core.i18n import get_default_language, resolve_language, t
+from app.core.i18n import get_default_language, normalize_language, resolve_language, t
 from app.models.user import User
 from app.models.site_setting import SiteSetting
 from app.schemas.token import Token
@@ -764,7 +764,7 @@ async def register(
         "force_password_change_first_login", False
     )
 
-    registration_locale = await resolve_language(user_in.locale)
+    registration_locale = normalize_language(user_in.locale) if user_in.locale else None
 
     # Create user
     hashed_password = security.get_password_hash(user_in.password)
@@ -813,6 +813,7 @@ async def register(
             resource_name=user.username,
             operation="create",
             status="success",
+            changes={"after": AuditLogService.snapshot(user, "user")},
             request=request,
             metadata={"is_first_user": True, "is_superuser": True},
         )
@@ -842,6 +843,7 @@ async def register(
         resource_name=user.username,
         operation="create",
         status="success",
+        changes={"after": AuditLogService.snapshot(user, "user")},
         request=request,
         metadata={
             "require_approval": require_approval,

--- a/backend/app/api/v1/endpoints/site_settings.py
+++ b/backend/app/api/v1/endpoints/site_settings.py
@@ -88,7 +88,7 @@ async def get_public_settings():
             site_description=settings.get("site_description", ""),
             site_url=settings.get("site_url", ""),
             site_icon=settings.get("site_icon", ""),
-            default_language=settings.get("default_language", "en"),
+            default_language=settings.get("default_language") or "en",
             auth_page_layout=settings.get("auth_page_layout", "centered"),
             theme_mode=_normalize_enum(
                 settings.get("theme_mode"), THEME_MODE_VALUES, "system"

--- a/backend/app/api/v1/endpoints/site_settings.py
+++ b/backend/app/api/v1/endpoints/site_settings.py
@@ -88,6 +88,7 @@ async def get_public_settings():
             site_description=settings.get("site_description", ""),
             site_url=settings.get("site_url", ""),
             site_icon=settings.get("site_icon", ""),
+            default_language=settings.get("default_language", "en"),
             auth_page_layout=settings.get("auth_page_layout", "centered"),
             theme_mode=_normalize_enum(
                 settings.get("theme_mode"), THEME_MODE_VALUES, "system"

--- a/backend/app/api/v1/endpoints/team_models.py
+++ b/backend/app/api/v1/endpoints/team_models.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Request
 
 from app.api import deps
-from app.core.i18n import t
+from app.core.i18n import t, get_default_language
 from app.models import Model, Team, TeamModel
 from app.models.notification import AutoNotificationType
 from app.models.user import TeamMember, User
@@ -160,12 +160,14 @@ async def add_team_model(
     team_model = await TeamModel.get(id=team_model.id).prefetch_related("model")
 
     # 发送模型授权通知给团队
+    default_lang = await get_default_language()
     await AutoNotificationService.send_to_team(
         notification_type=AutoNotificationType.TEAM_MODEL_GRANTED,
         team_id=team.id,
-        title=t("notify_team_model_granted_title"),
+        title=t("notify_team_model_granted_title", lang=default_lang),
         content=t(
             "notify_team_model_granted_content",
+            lang=default_lang,
             model_name=model.name,
             team_name=team.name,
         ),
@@ -338,12 +340,14 @@ async def remove_team_model(
     await team_model.delete()
 
     # 发送模型授权撤销通知给团队
+    default_lang = await get_default_language()
     await AutoNotificationService.send_to_team(
         notification_type=AutoNotificationType.TEAM_MODEL_REVOKED,
         team_id=team_id_for_notify,
-        title=t("notify_team_model_revoked_title"),
+        title=t("notify_team_model_revoked_title", lang=default_lang),
         content=t(
             "notify_team_model_revoked_content",
+            lang=default_lang,
             model_name=model_name,
             team_name=team_name,
         ),
@@ -462,12 +466,14 @@ async def batch_add_team_models(
     # 发送批量授权通知
     if results:
         model_names = [r["model"]["name"] for r in results]
+        default_lang = await get_default_language()
         await AutoNotificationService.send_to_team(
             notification_type=AutoNotificationType.TEAM_MODEL_GRANTED,
             team_id=team.id,
-            title=t("notify_team_model_granted_title"),
+            title=t("notify_team_model_granted_title", lang=default_lang),
             content=t(
                 "notify_team_model_granted_content",
+                lang=default_lang,
                 model_name=", ".join(model_names),
                 team_name=team.name,
             ),
@@ -532,12 +538,14 @@ async def batch_remove_team_models(
 
     # 发送批量撤销通知
     if deleted_count > 0 and model_names:
+        default_lang = await get_default_language()
         await AutoNotificationService.send_to_team(
             notification_type=AutoNotificationType.TEAM_MODEL_REVOKED,
             team_id=team.id,
-            title=t("notify_team_model_revoked_title"),
+            title=t("notify_team_model_revoked_title", lang=default_lang),
             content=t(
                 "notify_team_model_revoked_content",
+                lang=default_lang,
                 model_name=", ".join(model_names),
                 team_name=team.name,
             ),
@@ -548,7 +556,6 @@ async def batch_remove_team_models(
                 "team_name": team.name,
             },
         )
-
     await AuditLogService.log(
         user=current_user,
         action="batch_remove_team_models",

--- a/backend/app/api/v1/endpoints/teams.py
+++ b/backend/app/api/v1/endpoints/teams.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Request
 
 from app.api import deps
-from app.core.i18n import t, get_default_language
+from app.core.i18n import t, get_default_language, resolve_language
 from app.models.user import Team, TeamMember, User
 from app.models.notification import AutoNotificationType
 from app.schemas.team import (
@@ -258,13 +258,14 @@ async def add_team_member(
         },
     )
 
+    user_locale = await resolve_language(getattr(user_to_add, "locale", None))
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.TEAM_MEMBER_ADDED,
         user_id=user_to_add.id,
-        title=t("notify_team_member_added_title", lang=user_to_add.locale),
+        title=t("notify_team_member_added_title", lang=user_locale),
         content=t(
             "notify_team_member_added_content",
-            lang=user_to_add.locale,
+            lang=user_locale,
             team_name=team.name,
             operator=current_user.username,
             role=member_in.role,
@@ -361,13 +362,14 @@ async def update_team_member(
     membership.role = member_in.role
     await membership.save()
 
+    user_locale = await resolve_language(getattr(target_user, "locale", None))
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.TEAM_ROLE_CHANGED,
         user_id=target_user.id,
-        title=t("notify_team_role_changed_title", lang=target_user.locale),
+        title=t("notify_team_role_changed_title", lang=user_locale),
         content=t(
             "notify_team_role_changed_content",
-            lang=target_user.locale,
+            lang=user_locale,
             team_name=team.name,
             old_role=old_role,
             new_role=member_in.role,
@@ -463,13 +465,14 @@ async def remove_team_member(
         },
     )
 
+    user_locale = await resolve_language(getattr(target_user, "locale", None))
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.TEAM_MEMBER_REMOVED,
         user_id=target_user.id,
-        title=t("notify_team_member_removed_title", lang=target_user.locale),
+        title=t("notify_team_member_removed_title", lang=user_locale),
         content=t(
             "notify_team_member_removed_content",
-            lang=target_user.locale,
+            lang=user_locale,
             team_name=team.name,
         ),
     )
@@ -598,28 +601,30 @@ async def transfer_ownership(
     team = await Team.get(id=team_id).prefetch_related("owner")
 
     assert new_owner is not None
+    new_owner_locale = await resolve_language(getattr(new_owner, "locale", None))
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.TEAM_OWNERSHIP_TRANSFERRED,
         user_id=new_owner.id,
-        title=t("notify_team_ownership_received_title", lang=new_owner.locale),
+        title=t("notify_team_ownership_received_title", lang=new_owner_locale),
         content=t(
             "notify_team_ownership_received_content",
-            lang=new_owner.locale,
+            lang=new_owner_locale,
             team_name=team.name,
             old_owner=(
-                old_owner.username if old_owner else t("unknown", lang=new_owner.locale)
+                old_owner.username if old_owner else t("unknown", lang=new_owner_locale)
             ),
         ),
     )
 
     if old_owner:
+        old_owner_locale = await resolve_language(getattr(old_owner, "locale", None))
         await AutoNotificationService.send_to_user(
             notification_type=AutoNotificationType.TEAM_OWNERSHIP_TRANSFERRED,
             user_id=old_owner.id,
-            title=t("notify_team_ownership_transferred_title", lang=old_owner.locale),
+            title=t("notify_team_ownership_transferred_title", lang=old_owner_locale),
             content=t(
                 "notify_team_ownership_transferred_content",
-                lang=old_owner.locale,
+                lang=old_owner_locale,
                 team_name=team.name,
                 new_owner=new_owner.username,
             ),

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -7,7 +7,7 @@ from pydantic import EmailStr
 from app.api import deps
 from app.core import security
 from app.core.email import verify_code
-from app.core.i18n import t
+from app.core.i18n import t, resolve_language
 from app.core.password import validate_password, translate_password_validation_errors
 from app.models.user import User
 from app.models.site_setting import SiteSetting
@@ -249,11 +249,12 @@ async def change_password(
         request=request,
     )
 
+    user_locale = await resolve_language(getattr(current_user, "locale", None))
     await AutoNotificationService.send_to_user(
         notification_type=AutoNotificationType.SECURITY_PASSWORD_CHANGED,
         user_id=current_user.id,
-        title=t("notify_password_changed_title", lang=current_user.locale),
-        content=t("notify_password_changed_content", lang=current_user.locale),
+        title=t("notify_password_changed_title", lang=user_locale),
+        content=t("notify_password_changed_content", lang=user_locale),
         level=NotificationLevel.HIGH,
     )
 

--- a/backend/app/core/i18n.py
+++ b/backend/app/core/i18n.py
@@ -102,16 +102,70 @@ def set_language(lang: str) -> None:
     current_language.set(normalize_language(lang))
 
 
+_cached_default_language: str = Language.EN.value
+
+
 async def get_default_language() -> str:
     """Get default language from site settings.
 
     This is used for system messages when no specific user locale is available,
     such as team notifications, webhook-triggered workflows, etc.
     """
+    global _cached_default_language
     from app.models.site_setting import SiteSetting
 
-    lang = await SiteSetting.get_value("default_language", "en")
-    return normalize_language(str(lang))
+    try:
+        lang = await SiteSetting.get_value("default_language", "en")
+        _cached_default_language = normalize_language(str(lang))
+    except Exception:
+        pass
+    return _cached_default_language
+
+
+def get_default_language_sync() -> str:
+    """Get cached default language from site settings synchronously."""
+    return _cached_default_language
+
+
+def set_default_language_cache(lang: str | None) -> None:
+    """Update cached default language."""
+    global _cached_default_language
+    if lang:
+        _cached_default_language = normalize_language(lang)
+
+
+async def resolve_language(
+    user_locale: str | None = None,
+    default_override: str | None = None,
+) -> str:
+    """Resolve language according to: User > System (SiteSetting) > Default ('en').
+
+    Args:
+        user_locale: Explicit user locale (from user.locale or request/parameter).
+        default_override: Optional fallback if system default is absent.
+
+    Returns:
+        Normalized language code ('en', 'zh', etc.).
+    """
+    if user_locale and str(user_locale).strip():
+        return normalize_language(user_locale)
+    system_default = await get_default_language()
+    if system_default and str(system_default).strip():
+        return normalize_language(system_default)
+    return normalize_language(default_override or Language.EN.value)
+
+
+def resolve_language_sync(
+    user_locale: str | None = None,
+    default_override: str | None = None,
+) -> str:
+    """Resolve language synchronously according to: User > System (Cached) > Default ('en')."""
+    if user_locale and str(user_locale).strip():
+        return normalize_language(user_locale)
+    system_default = get_default_language_sync()
+    if system_default and str(system_default).strip():
+        return normalize_language(system_default)
+    return normalize_language(default_override or Language.EN.value)
 
 
 def t(key: str, lang: Optional[str] = None, **kwargs) -> str:

--- a/backend/app/core/i18n.py
+++ b/backend/app/core/i18n.py
@@ -103,6 +103,7 @@ def set_language(lang: str) -> None:
 
 
 _cached_default_language: str = Language.EN.value
+_cached_default_language_version: int = 0
 
 
 async def get_default_language() -> str:
@@ -111,12 +112,15 @@ async def get_default_language() -> str:
     This is used for system messages when no specific user locale is available,
     such as team notifications, webhook-triggered workflows, etc.
     """
-    global _cached_default_language
+    global _cached_default_language, _cached_default_language_version
     from app.models.site_setting import SiteSetting
 
+    read_version = _cached_default_language_version
     try:
         lang = await SiteSetting.get_value("default_language", "en")
-        _cached_default_language = normalize_language(str(lang))
+        # Only update cache if no newer write has updated the cache version
+        if _cached_default_language_version == read_version:
+            _cached_default_language = normalize_language(str(lang))
     except Exception:
         pass
     return _cached_default_language
@@ -128,8 +132,9 @@ def get_default_language_sync() -> str:
 
 
 def set_default_language_cache(lang: str | None) -> None:
-    """Update cached default language."""
-    global _cached_default_language
+    """Update cached default language and advance cache version."""
+    global _cached_default_language, _cached_default_language_version
+    _cached_default_language_version += 1
     if lang:
         _cached_default_language = normalize_language(lang)
 

--- a/backend/app/core/i18n.py
+++ b/backend/app/core/i18n.py
@@ -135,8 +135,7 @@ def set_default_language_cache(lang: str | None) -> None:
     """Update cached default language and advance cache version."""
     global _cached_default_language, _cached_default_language_version
     _cached_default_language_version += 1
-    if lang:
-        _cached_default_language = normalize_language(lang)
+    _cached_default_language = normalize_language(lang)
 
 
 async def resolve_language(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.core.i18n import (
     get_code_message,
     has_translation,
     get_language,
+    get_default_language,
 )
 from app.core.redis import close_redis
 from app.schemas.response import success, error, ResponseCode, BusinessError
@@ -567,13 +568,14 @@ class LoggingMiddleware(BaseHTTPMiddleware):
 # Language middleware to set language from Accept-Language header
 class LanguageMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        # Get language from Accept-Language header or X-Language header
-        lang = request.headers.get("X-Language") or request.headers.get(
-            "Accept-Language", "en"
+        header_lang = request.headers.get("X-Language") or request.headers.get(
+            "Accept-Language"
         )
-        # Parse Accept-Language (e.g., "zh-CN,zh;q=0.9,en;q=0.8" -> "zh")
-        lang = lang.split(",")[0].split(";")[0].strip()
-        set_language(lang)
+        if header_lang:
+            lang = header_lang.split(",")[0].split(";")[0].strip()
+            set_language(lang)
+        else:
+            set_language(await get_default_language())
         response = await call_next(request)
         return response
 

--- a/backend/app/models/site_setting.py
+++ b/backend/app/models/site_setting.py
@@ -79,6 +79,13 @@ class SiteSetting(models.Model):
                 setting.description = description
             setting.is_public = is_public
             await setting.save()
+        if key == "default_language":
+            try:
+                from app.core.i18n import set_default_language_cache
+
+                set_default_language_cache(str(value))
+            except Exception:
+                pass
         return setting
 
     @classmethod

--- a/backend/app/models/site_setting.py
+++ b/backend/app/models/site_setting.py
@@ -83,7 +83,7 @@ class SiteSetting(models.Model):
             try:
                 from app.core.i18n import set_default_language_cache
 
-                set_default_language_cache(str(value))
+                set_default_language_cache(str(value) if value is not None else None)
             except Exception:
                 pass
         return setting

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -158,7 +158,7 @@ class User(models.Model):
     )
     locale = fields.CharField(
         max_length=10,
-        default="en",
+        null=True,
         description="User preferred locale (e.g., en, zh)",
     )
     created_at = fields.DatetimeField(auto_now_add=True)

--- a/backend/app/schemas/site_setting.py
+++ b/backend/app/schemas/site_setting.py
@@ -33,6 +33,7 @@ class PublicSiteSettingsResponse(BaseModel):
     site_description: str = ""
     site_url: str = ""
     site_icon: str = ""
+    default_language: str = "en"
     auth_page_layout: str = "centered"
     theme_mode: str = "system"
     theme_primary_color: str = ""

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -56,7 +56,7 @@ class UserBase(BaseModel):
     approval_status: Optional[str] = "approved"
     is_superuser: Optional[bool] = False
     avatar_url: Optional[str] = None
-    locale: Optional[str] = "en"
+    locale: Optional[str] = None
 
 
 class UserCreate(UserBase):

--- a/backend/app/services/agent_run_worker.py
+++ b/backend/app/services/agent_run_worker.py
@@ -250,14 +250,16 @@ async def _rebuild_context(
     )
     chat_model = await resolve_agent_chat_model(agent)
     tools_openai = await _load_tools(agent)
-    tool_display_names = await _load_tool_display_names(
-        agent, payload.get("locale") or "en"
-    )
+    from app.core.i18n import resolve_language, set_language
+
+    effective_locale = await resolve_language(payload.get("locale"))
+    set_language(effective_locale)
+    tool_display_names = await _load_tool_display_names(agent, effective_locale)
     file_content, _ = await build_file_content_for_context(
         agent=agent,
         file_urls=payload.get("file_urls") or [],
         legacy_files=payload.get("legacy_files") or [],
-        user_locale=payload.get("locale"),
+        user_locale=effective_locale,
         tool_timeouts=streaming_config["tool_timeouts"],
         user=SimpleNamespace(id=conversation.user_id),
     )
@@ -320,7 +322,7 @@ async def _rebuild_context(
         conversation=conversation,
         user=SimpleNamespace(
             id=conversation.user_id,
-            locale=payload.get("locale") or "en",
+            locale=effective_locale,
         ),
         user_message=image_inventory_text,
         model_id=chat_model.model_id,
@@ -352,7 +354,7 @@ async def _rebuild_context(
         history_before_message_created_at=history_before,
         round_id=UUID(payload["round_id"]),
         protected_round_id=UUID(payload["round_id"]),
-        user_locale=payload.get("locale"),
+        user_locale=effective_locale,
         max_iterations=None,
         iteration_offset=int(payload.get("iteration_offset", 0)),
         streaming=is_streaming,
@@ -368,9 +370,7 @@ async def _rebuild_context(
         formatter=_RunFormatter(event_queue, agent=agent),
         first_round_index=int(payload.get("first_round_index", 1)),
         created_message_count=int(payload.get("created_message_count", 2)),
-        cap_content=lambda: build_max_iterations_terminal_content(
-            payload.get("locale") or "en"
-        ),
+        cap_content=lambda: build_max_iterations_terminal_content(effective_locale),
     )
 
     async def build_turn(**kwargs):
@@ -456,6 +456,10 @@ async def _transition_active_run(
 async def run_agent_round(payload: dict[str, Any]) -> dict[str, Any]:
     """Execute one run payload to terminal and persist the canonical round."""
     payload = dict(payload)
+    from app.core.i18n import resolve_language, set_language
+
+    worker_locale = await resolve_language(payload.get("locale"))
+    set_language(worker_locale)
     resume_tool_result = payload.pop("resume_tool_result", None)
     run = await agent_run_store.get_run(UUID(payload["run_id"]))
     if not run:
@@ -917,8 +921,11 @@ async def _finalize_completed(
     )
     from app.models.agent import Message as M
 
+    from app.core.i18n import resolve_language
+
+    effective_locale = await resolve_language(locale)
     terminal_content = (
-        build_max_iterations_terminal_content(locale or "en")
+        build_max_iterations_terminal_content(effective_locale)
         if result.max_iterations_reached
         else result.full_content or ""
     )

--- a/backend/app/services/system_prompt.py
+++ b/backend/app/services/system_prompt.py
@@ -177,8 +177,10 @@ _CITATION_SOURCE_BUILTIN_TOOLS = frozenset({"web_search", "fetch_webpage"})
 
 
 def normalize_locale(user_locale: str | None) -> str:
-    """Return the base language subtag, defaulting to ``en``."""
-    return (user_locale or "en").lower().split("-")[0]
+    """Return the base language subtag, defaulting to system default or ``en``."""
+    from app.core.i18n import resolve_language_sync
+
+    return resolve_language_sync(user_locale)
 
 
 def get_language_instruction(user_locale: str | None = None) -> str:

--- a/backend/app/services/workflow/executors/tool.py
+++ b/backend/app/services/workflow/executors/tool.py
@@ -251,11 +251,14 @@ class AgentNodeExecutor(NodeExecutor):
 
         try:
             agent_service = AgentService()
-            user_locale = "en"
+            from app.core.i18n import resolve_language
+
+            triggered_user_locale = None
             if run.triggered_by_id:
                 await run.fetch_related("triggered_by")
                 if run.triggered_by:
-                    user_locale = getattr(run.triggered_by, "locale", None) or "en"
+                    triggered_user_locale = getattr(run.triggered_by, "locale", None)
+            user_locale = await resolve_language(triggered_user_locale)
             if (images or files) and not getattr(agent, "enable_attachments", False):
                 return ExecutionResult(error="attachments_not_enabled")
             configured_turns = config.get("maxTurns")

--- a/backend/app/services/workflow/orchestrator.py
+++ b/backend/app/services/workflow/orchestrator.py
@@ -859,7 +859,9 @@ class WorkflowOrchestrator:
                             workflow_name=workflow.name,
                             error=error[:200]
                             if error
-                            else t("unknown_error"),  # Truncate long errors
+                            else t(
+                                "unknown_error", lang=default_lang
+                            ),  # Truncate long errors
                         ),
                         data={
                             "workflow_id": str(workflow.id),

--- a/backend/app/services/workflow/orchestrator.py
+++ b/backend/app/services/workflow/orchestrator.py
@@ -25,7 +25,7 @@ from app.models.workflow import (
 from app.models.user import Team
 from app.models.notification import AutoNotificationType
 from app.core.redis import get_redis
-from app.core.i18n import t, get_default_language
+from app.core.i18n import t, get_default_language, resolve_language
 from app.services.auto_notification import AutoNotificationService
 
 from .context import ExecutionContext
@@ -710,11 +710,12 @@ class WorkflowOrchestrator:
                 # Send to triggering user if available, otherwise to team
                 if run.triggered_by_id:
                     await run.fetch_related("triggered_by")
-                    user_locale = (
-                        getattr(run.triggered_by, "locale", "en")
+                    triggered_user_locale = (
+                        getattr(run.triggered_by, "locale", None)
                         if run.triggered_by
-                        else "en"
+                        else None
                     )
+                    user_locale = await resolve_language(triggered_user_locale)
                     await AutoNotificationService.send_to_user(
                         notification_type=AutoNotificationType.WORKFLOW_RUN_SUCCESS,
                         user_id=run.triggered_by_id,
@@ -817,11 +818,12 @@ class WorkflowOrchestrator:
                 # Send to triggering user if available, otherwise to team
                 if run.triggered_by_id:
                     await run.fetch_related("triggered_by")
-                    user_locale = (
-                        getattr(run.triggered_by, "locale", "en")
+                    triggered_user_locale = (
+                        getattr(run.triggered_by, "locale", None)
                         if run.triggered_by
-                        else "en"
+                        else None
                     )
+                    user_locale = await resolve_language(triggered_user_locale)
                     await AutoNotificationService.send_to_user(
                         notification_type=AutoNotificationType.WORKFLOW_RUN_FAILED,
                         user_id=run.triggered_by_id,
@@ -832,7 +834,9 @@ class WorkflowOrchestrator:
                             workflow_name=workflow.name,
                             error=error[:200]
                             if error
-                            else t("unknown_error"),  # Truncate long errors
+                            else t(
+                                "unknown_error", lang=user_locale
+                            ),  # Truncate long errors
                         ),
                         data={
                             "workflow_id": str(workflow.id),

--- a/backend/app/services/workflow/pause_approvers.py
+++ b/backend/app/services/workflow/pause_approvers.py
@@ -11,7 +11,7 @@ import logging
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
-from app.core.i18n import t
+from app.core.i18n import t, resolve_language
 from app.models.notification import (
     AutoNotificationType,
     Notification,
@@ -129,7 +129,7 @@ async def notify_pause_pending(
             else "notify_workflow_input_pending_content"
         )
         for user in users:
-            lang = user.locale or "en"
+            lang = await resolve_language(getattr(user, "locale", None))
             user_content = t(
                 content_key,
                 lang=lang,

--- a/backend/app/tasks/api_key.py
+++ b/backend/app/tasks/api_key.py
@@ -6,7 +6,7 @@ import logging
 from datetime import timedelta
 
 from app.core.celery import celery_app
-from app.core.i18n import t
+from app.core.i18n import t, resolve_language
 from app.core.timezone import now_utc
 from app.models.api_key import APIKey
 from app.models.notification import AutoNotificationType, NotificationLevel
@@ -72,7 +72,7 @@ async def _check_api_key_expiration():
             continue
 
         # 获取用户语言偏好
-        user_locale = getattr(api_key.user, "locale", "en")
+        user_locale = await resolve_language(getattr(api_key.user, "locale", None))
 
         await AutoNotificationService.send_to_user(
             notification_type=AutoNotificationType.APIKEY_EXPIRING,
@@ -110,7 +110,7 @@ async def _check_api_key_expiration():
 
     for api_key in expired_keys:
         # 获取用户语言偏好
-        user_locale = getattr(api_key.user, "locale", "en")
+        user_locale = await resolve_language(getattr(api_key.user, "locale", None))
 
         await AutoNotificationService.send_to_user(
             notification_type=AutoNotificationType.APIKEY_EXPIRED,

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -11,12 +11,13 @@ from uuid import UUID
 from celery import shared_task
 from tortoise.functions import Sum
 
-from app.core.i18n import t, get_default_language
+from app.core.i18n import t, get_default_language, resolve_language
 from app.models.knowledge_base import (
     Document,
     DocumentChunk,
     DocumentStatus,
 )
+from app.models.user import User
 from app.models.notification import AutoNotificationType
 from app.services.auto_notification import AutoNotificationService
 from app.services.document_processor import document_processor
@@ -299,19 +300,23 @@ async def _send_doc_indexed_notification(
     team_id: UUID,
     chunk_count: int,
     token_count: int,
-    user_locale: str = "en",
+    user_locale: str | None = None,
 ) -> None:
     """Send notification when document is indexed successfully."""
     try:
         # Send to uploader if available, otherwise to team
         if document.uploaded_by_id:
+            user = await User.filter(id=document.uploaded_by_id).first()
+            effective_locale = await resolve_language(
+                getattr(user, "locale", None) if user else user_locale
+            )
             await AutoNotificationService.send_to_user(
                 notification_type=AutoNotificationType.KB_DOC_INDEXED,
                 user_id=document.uploaded_by_id,
-                title=t("notify_kb_doc_indexed_title", lang=user_locale),
+                title=t("notify_kb_doc_indexed_title", lang=effective_locale),
                 content=t(
                     "notify_kb_doc_indexed_content",
-                    lang=user_locale,
+                    lang=effective_locale,
                     doc_name=document.name,
                     kb_name=kb_name,
                     chunk_count=chunk_count,
@@ -358,19 +363,23 @@ async def _send_doc_failed_notification(
     kb_name: str,
     team_id: UUID,
     error: str,
-    user_locale: str = "en",
+    user_locale: str | None = None,
 ) -> None:
     """Send notification when document indexing fails."""
     try:
         # Send to uploader if available, otherwise to team
         if document.uploaded_by_id:
+            user = await User.filter(id=document.uploaded_by_id).first()
+            effective_locale = await resolve_language(
+                getattr(user, "locale", None) if user else user_locale
+            )
             await AutoNotificationService.send_to_user(
                 notification_type=AutoNotificationType.KB_DOC_FAILED,
                 user_id=document.uploaded_by_id,
-                title=t("notify_kb_doc_failed_title", lang=user_locale),
+                title=t("notify_kb_doc_failed_title", lang=effective_locale),
                 content=t(
                     "notify_kb_doc_failed_content",
-                    lang=user_locale,
+                    lang=effective_locale,
                     doc_name=document.name,
                     kb_name=kb_name,
                     error=error[:200],  # Truncate error message

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -17,7 +17,6 @@ from app.models.knowledge_base import (
     DocumentChunk,
     DocumentStatus,
 )
-from app.models.user import User
 from app.models.notification import AutoNotificationType
 from app.services.auto_notification import AutoNotificationService
 from app.services.document_processor import document_processor
@@ -306,7 +305,7 @@ async def _send_doc_indexed_notification(
     try:
         # Send to uploader if available, otherwise to team
         if document.uploaded_by_id:
-            user = await User.filter(id=document.uploaded_by_id).first()
+            user = getattr(document, "uploaded_by", None)
             effective_locale = await resolve_language(
                 getattr(user, "locale", None) if user else user_locale
             )
@@ -369,7 +368,7 @@ async def _send_doc_failed_notification(
     try:
         # Send to uploader if available, otherwise to team
         if document.uploaded_by_id:
-            user = await User.filter(id=document.uploaded_by_id).first()
+            user = getattr(document, "uploaded_by", None)
             effective_locale = await resolve_language(
                 getattr(user, "locale", None) if user else user_locale
             )

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -140,9 +140,7 @@ def backfill_lexical_index_task(
 
 
 def _get_document_error_lang(document: Document, user_locale: str = "en") -> str:
-    if document.uploaded_by_id:
-        return user_locale
-    return "en"
+    return user_locale
 
 
 def _get_dimension_mismatch_error(document: Document, user_locale: str = "en") -> str:
@@ -255,8 +253,9 @@ async def _finish_upload_gateway_retry_exhaustion(
         return await _finish_already_finished_task(document, task_id)
 
     kb = document.knowledge_base
-    user_locale = (
-        getattr(document.uploaded_by, "locale", "en") if document.uploaded_by else "en"
+    uploader = getattr(document, "uploaded_by", None)
+    user_locale = await resolve_language(
+        getattr(uploader, "locale", None) if uploader else None
     )
     logger.error(
         "Upload gateway retries exhausted for document %s: %s", document_id, error
@@ -441,10 +440,10 @@ async def _process_document(document_id: str, task_id: str | None) -> dict[str, 
 
     kb = document.knowledge_base
     # Get uploader's locale for notifications
-    user_locale = (
-        getattr(document.uploaded_by, "locale", "en") if document.uploaded_by else "en"
+    uploader = getattr(document, "uploaded_by", None)
+    user_locale = await resolve_language(
+        getattr(uploader, "locale", None) if uploader else None
     )
-
     existing_chunks = await DocumentChunk.filter(document_id=doc_uuid).count()
     if existing_chunks > 0:
         return await _embed_existing_document_chunks(document_id, task_id)
@@ -855,10 +854,9 @@ def rechunk_document_task(self, document_id: str) -> dict:
 
         kb = document.knowledge_base
         # Get uploader's locale for notifications
-        user_locale = (
-            getattr(document.uploaded_by, "locale", "en")
-            if document.uploaded_by
-            else "en"
+        uploader = getattr(document, "uploaded_by", None)
+        user_locale = await resolve_language(
+            getattr(uploader, "locale", None) if uploader else None
         )
 
         try:
@@ -1103,8 +1101,9 @@ async def _embed_existing_document_chunks(
     kb = document.knowledge_base
     kb_id = cast(UUID, kb.id)
     kb_team_id = cast(UUID, kb.team_id)
-    user_locale = (
-        getattr(document.uploaded_by, "locale", "en") if document.uploaded_by else "en"
+    uploader = getattr(document, "uploaded_by", None)
+    user_locale = await resolve_language(
+        getattr(uploader, "locale", None) if uploader else None
     )
 
     async def _refresh_kb_stats() -> None:
@@ -1406,10 +1405,9 @@ def retry_failed_chunks_task(self, document_id: str) -> dict:
             return await _finish_already_finished_task(document, task_id)
 
         kb = document.knowledge_base
-        user_locale = (
-            getattr(document.uploaded_by, "locale", "en")
-            if document.uploaded_by
-            else "en"
+        uploader = getattr(document, "uploaded_by", None)
+        user_locale = await resolve_language(
+            getattr(uploader, "locale", None) if uploader else None
         )
 
         try:
@@ -1643,10 +1641,9 @@ def retry_failed_chunk_task(self, document_id: str, chunk_id: str) -> dict:
             return await _finish_already_finished_task(document, task_id)
 
         kb = document.knowledge_base
-        user_locale = (
-            getattr(document.uploaded_by, "locale", "en")
-            if document.uploaded_by
-            else "en"
+        uploader = getattr(document, "uploaded_by", None)
+        user_locale = await resolve_language(
+            getattr(uploader, "locale", None) if uploader else None
         )
 
         chunk = await DocumentChunk.filter(id=chunk_uuid, document_id=doc_uuid).first()

--- a/backend/app/tasks/password_expiration.py
+++ b/backend/app/tasks/password_expiration.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timezone
 
 from app.core.celery import celery_app
-from app.core.i18n import t
+from app.core.i18n import t, resolve_language
 from app.models.user import User
 from app.models.site_setting import SiteSetting
 from app.models.notification import AutoNotificationType, NotificationLevel
@@ -96,7 +96,7 @@ async def _check_password_expiration():
                 not user.password_expiration_notified_at
                 or (now - user.password_expiration_notified_at).days >= 1
             ):
-                user_locale = getattr(user, "locale", "en")
+                user_locale = await resolve_language(getattr(user, "locale", None))
 
                 await AutoNotificationService.send_to_user(
                     notification_type=AutoNotificationType.PASSWORD_EXPIRED,
@@ -130,7 +130,7 @@ async def _check_password_expiration():
             ):
                 continue
 
-            user_locale = getattr(user, "locale", "en")
+            user_locale = await resolve_language(getattr(user, "locale", None))
 
             await AutoNotificationService.send_to_user(
                 notification_type=AutoNotificationType.PASSWORD_EXPIRING,

--- a/backend/tests/api/test_site_settings_normalization_issue255.py
+++ b/backend/tests/api/test_site_settings_normalization_issue255.py
@@ -26,3 +26,19 @@ def test_normalize_hex_color_rejects_non_hex_digits():
 )
 def test_normalize_kb_document_upload_size_bounds(value, expected):
     assert _normalize_kb_document_max_upload_size_mb(value) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_public_settings_includes_default_language(monkeypatch):
+    from app.api.v1.endpoints.site_settings import get_public_settings
+    from app.models import SiteSetting
+
+    monkeypatch.setattr(
+        SiteSetting,
+        "get_all_by_category",
+        lambda public_only=True: __import__("asyncio").sleep(
+            0, result={"default_language": "zh"}
+        ),
+    )
+    response = await get_public_settings()
+    assert response["data"].default_language == "zh"

--- a/backend/tests/api/test_site_settings_normalization_issue255.py
+++ b/backend/tests/api/test_site_settings_normalization_issue255.py
@@ -42,3 +42,22 @@ async def test_get_public_settings_includes_default_language(monkeypatch):
     )
     response = await get_public_settings()
     assert response["data"].default_language == "zh"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("falsey_lang", [None, ""])
+async def test_get_public_settings_default_language_falsey_fallback(
+    monkeypatch, falsey_lang
+):
+    from app.api.v1.endpoints.site_settings import get_public_settings
+    from app.models import SiteSetting
+
+    monkeypatch.setattr(
+        SiteSetting,
+        "get_all_by_category",
+        lambda public_only=True: __import__("asyncio").sleep(
+            0, result={"default_language": falsey_lang}
+        ),
+    )
+    response = await get_public_settings()
+    assert response["data"].default_language == "en"

--- a/backend/tests/services/test_system_prompt_manager.py
+++ b/backend/tests/services/test_system_prompt_manager.py
@@ -281,6 +281,38 @@ def test_workflow_mode_locale_drives_language_instruction():
     assert "你必须使用中文回复" in prompt
 
 
+def test_system_prompt_uses_system_default_language_when_user_locale_none():
+    from app.core import i18n
+
+    try:
+        i18n.set_default_language_cache("zh")
+        prompt = build_system_prompt(
+            _agent(system_prompt="base"),
+            user_message="hi",
+            user_locale=None,
+            invocation_mode=WORKFLOW_MODE,
+        )
+        assert "你必须使用中文回复" in prompt
+    finally:
+        i18n.set_default_language_cache("en")
+
+
+def test_system_prompt_user_locale_overrides_system_default_language():
+    from app.core import i18n
+
+    try:
+        i18n.set_default_language_cache("zh")
+        prompt = build_system_prompt(
+            _agent(system_prompt="base"),
+            user_message="hi",
+            user_locale="en",
+            invocation_mode=WORKFLOW_MODE,
+        )
+        assert "You MUST respond in English only." in prompt
+    finally:
+        i18n.set_default_language_cache("en")
+
+
 def test_base_prompt_override_is_used_instead_of_agent_prompt():
     prompt = build_system_prompt(
         _agent(system_prompt="original"),

--- a/backend/tests/test_i18n.py
+++ b/backend/tests/test_i18n.py
@@ -153,6 +153,35 @@ async def test_resolve_language_follows_user_system_default_precedence(monkeypat
     assert await i18n.resolve_language(None) == "en"
 
 
+@pytest.mark.asyncio
+async def test_get_default_language_discards_stale_fetch_if_cache_updated(monkeypatch):
+    import asyncio
+    from app.models import SiteSetting
+
+    i18n.set_default_language_cache("en")
+
+    async def slow_get_value(key, default):
+        await asyncio.sleep(0.01)
+        return "es"
+
+    monkeypatch.setattr(SiteSetting, "get_value", slow_get_value)
+
+    fetch_task = asyncio.create_task(i18n.get_default_language())
+    await asyncio.sleep(
+        0
+    )  # Yield to allow fetch_task to begin and capture read_version
+
+    # Simulate concurrent settings write advancing cache version while fetch is in-flight
+    i18n.set_default_language_cache("zh")
+    assert i18n.get_default_language_sync() == "zh"
+
+    result = await fetch_task
+    # Stale read should not overwrite "zh"
+    assert i18n.get_default_language_sync() == "zh"
+    assert result == "zh"
+    i18n.set_default_language_cache("en")
+
+
 def test_resolve_language_sync_follows_user_system_default_precedence(monkeypatch):
     # 1. User specified -> user wins over system and default
     i18n.set_default_language_cache("zh")

--- a/backend/tests/test_i18n.py
+++ b/backend/tests/test_i18n.py
@@ -118,3 +118,81 @@ def test_code_message_uses_unknown_error_for_unmapped_or_invalid_codes(monkeypat
     assert i18n.get_code_message(999999, lang="zh") == "unknown_error"
 
     assert translated_keys == [("unknown_error", "zh")]
+
+
+@pytest.mark.asyncio
+async def test_resolve_language_follows_user_system_default_precedence(monkeypatch):
+    # 1. User specified -> user wins over system and default
+    monkeypatch.setattr(
+        i18n,
+        "get_default_language",
+        lambda: __import__("asyncio").sleep(0, result="zh"),
+    )
+    assert await i18n.resolve_language("en") == "en"
+
+    monkeypatch.setattr(
+        i18n,
+        "get_default_language",
+        lambda: __import__("asyncio").sleep(0, result="en"),
+    )
+    assert await i18n.resolve_language("zh-CN") == "zh"
+
+    # 2. No user specified -> system wins over default
+    monkeypatch.setattr(
+        i18n,
+        "get_default_language",
+        lambda: __import__("asyncio").sleep(0, result="zh"),
+    )
+    assert await i18n.resolve_language(None) == "zh"
+    assert await i18n.resolve_language("") == "zh"
+
+    # 3. Neither specified -> default ('en') wins
+    monkeypatch.setattr(
+        i18n, "get_default_language", lambda: __import__("asyncio").sleep(0, result="")
+    )
+    assert await i18n.resolve_language(None) == "en"
+
+
+def test_resolve_language_sync_follows_user_system_default_precedence(monkeypatch):
+    # 1. User specified -> user wins over system and default
+    i18n.set_default_language_cache("zh")
+    assert i18n.resolve_language_sync("en") == "en"
+
+    i18n.set_default_language_cache("en")
+    assert i18n.resolve_language_sync("zh-CN") == "zh"
+
+    # 2. No user specified -> system wins over default
+    i18n.set_default_language_cache("zh")
+    assert i18n.resolve_language_sync(None) == "zh"
+    assert i18n.resolve_language_sync("") == "zh"
+
+    # 3. Neither specified -> default ('en') wins
+    i18n.set_default_language_cache(None)
+    monkeypatch.setattr(i18n, "_cached_default_language", "")
+    assert i18n.resolve_language_sync(None) == "en"
+
+
+def test_system_prompt_and_terminal_content_follow_user_system_default_precedence():
+    from app.services.system_prompt import build_system_prompt
+    from app.api.v1.endpoints.chat import build_max_iterations_terminal_content
+    from types import SimpleNamespace
+
+    agent = SimpleNamespace(id="agent-test", system_prompt="", tools_config=[])
+
+    try:
+        # System is configured as Chinese
+        i18n.set_default_language_cache("zh")
+
+        # Case A: user has no preference -> system default (zh) applies
+        prompt = build_system_prompt(agent, user_locale=None)
+        assert "## 回复语言\n你必须使用中文回复。不要使用其他语言。" in prompt
+        terminal = build_max_iterations_terminal_content(user_locale=None)
+        assert "本轮已达到最大工具调用轮次" in terminal
+
+        # Case B: user explicitly requests English -> user (en) wins over system (zh)
+        prompt_en = build_system_prompt(agent, user_locale="en")
+        assert "## Response Language\nYou MUST respond in English only." in prompt_en
+        terminal_en = build_max_iterations_terminal_content(user_locale="en")
+        assert "maximum tool-call iterations" in terminal_en
+    finally:
+        i18n.set_default_language_cache("en")

--- a/frontend/contexts/site-settings-context.tsx
+++ b/frontend/contexts/site-settings-context.tsx
@@ -18,6 +18,7 @@ const defaultSettings: PublicSiteSettings = {
   site_description: '',
   site_url: '',
   site_icon: '',
+  default_language: 'en',
   theme_mode: 'system',
   theme_primary_color: '',
   theme_primary_foreground_color: '',

--- a/frontend/lib/api/site-settings.ts
+++ b/frontend/lib/api/site-settings.ts
@@ -24,6 +24,7 @@ export interface PublicSiteSettings {
   site_description: string
   site_url: string
   site_icon: string
+  default_language?: string
   auth_page_layout: AuthPageLayout
   theme_mode: ThemeMode
   theme_primary_color: string


### PR DESCRIPTION
## Summary
Fix an issue where system-generated and default messages (including agent system prompts, background Celery worker messages, scheduled notifications, and site settings) fell back to English instead of respecting the configured system default language (`SiteSetting.default_language`).

### Language Precedence
Strictly align with:
**User Preference (`User.locale`) > System Setting (`SiteSetting.default_language`) > Hardcoded Default (`"en"`)**

### Key Changes
1. **Core Language Resolution (`backend/app/core/i18n.py`)**:
   - Added `resolve_language` (async) and `resolve_language_sync` (sync) implementing the User > System > Default hierarchy.
   - Added thread-safe in-memory cache for `default_language` with immediate cache updates when `SiteSetting` is modified.
2. **Agent Chat & System Prompts (`system_prompt.py`, `chat.py`, `agent_run_worker.py`)**:
   - `system_prompt.normalize_locale` now uses `resolve_language_sync(user_locale)`, injecting the correct system default language instructions when no user preference is specified.
   - Preserves normalized language into the agent run payload and Celery task execution, ensuring iteration limits (`chat_max_iterations_reached`), summaries, and built-in tool labels use the effective locale.
3. **Automated & Scheduled Notifications**:
   - System/team notifications (e.g. agent publication, model authorization) use `get_default_language()`.
   - User notifications (password expiration, API key expiration, knowledge base document indexing, workflow execution) resolve via `resolve_language(user.locale)`.
4. **Public Site Settings & Frontend Types**:
   - Exposed `default_language` in `GET /api/v1/site-settings/public` (`PublicSiteSettingsResponse`).
   - Added `default_language` to `PublicSiteSettings` interface and `SiteSettingsContext` in frontend.
5. **Tests**:
   - Added comprehensive precedence tests in `test_i18n.py` (User vs System vs Default).
   - Added system default language prompt tests in `test_system_prompt_manager.py`.
   - Added public settings response tests in `test_site_settings_normalization_issue255.py`.

## Verification
- `pytest backend/tests/test_i18n.py backend/tests/services/test_system_prompt_manager.py backend/tests/tasks/test_password_expiration.py backend/tests/tasks/test_api_key.py backend/tests/api/test_site_settings_normalization_issue255.py` (73 passed)
- `bun test frontend/contexts/site-settings-context.test.tsx` (passed)
- Pre-commit checks: Ruff formatting & linting, ESLint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable default-language support for public site settings.
  * Notifications, chat responses, agent workflows, and system prompts now resolve each user’s language preference with a system-default fallback.
  * Public settings now expose the configured default language.
  * Users without an explicit locale now inherit the configured system language.

* **Bug Fixes**
  * Improved language fallback behavior across login, notifications, workflows, and background tasks.
  * Added coverage for language precedence and public settings responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->