### PR TITLE
fix(chat): prevent history refresh flicker and toast load failures

### DIFF
--- a/frontend/app/(chat)/chat/[id]/page.test.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.test.tsx
@@ -313,6 +313,24 @@ describe('PublicChatPage', () => {
     })
   })
 
+  test('prevents empty chat flash and preserves sidebar conversation items on refresh', async () => {
+    query = new URLSearchParams('conversation=conv-1')
+    render()
+    await flush()
+
+    // On initial load with conversation in URL, ChatContainer should receive loaded messages without key recreation
+    expect(setConversationId).toHaveBeenCalledWith('conv-1')
+    expect(setMessages).toHaveBeenCalled()
+
+    // When onStreamEnd triggers refreshConversations with identical items
+    getConversations.mockResolvedValueOnce({ items: conversations, total: 2 })
+    await act(async () => {
+      chatOptions.onStreamEnd?.()
+      await Promise.resolve()
+    })
+    expect(getConversations).toHaveBeenCalledTimes(2)
+  })
+
   test('places the queued label in the conversation instead of below the composer', async () => {
     chatState.messages = [{ id: 'assistant-loading', role: 'assistant', parts: [], metadata: { isLoading: true } }]
     chatState.isLoading = true
@@ -738,6 +756,7 @@ describe('PublicChatPage', () => {
     await flush()
     expect(historyReplace).toHaveBeenCalledWith({}, '', '/chat/agent-1?source=share')
     expect(output()).not.toContain('private conversation detail')
+    expect(toastError).toHaveBeenCalledWith('private conversation detail')
     act(() => renderer!.unmount())
 
     getPublicAgent.mockRejectedValueOnce(new Error('private agent detail'))
@@ -762,7 +781,7 @@ describe('PublicChatPage', () => {
     await act(async () => firstChat.props.onClick())
     expect(getConversation).toHaveBeenCalledWith('conv-1')
     expect(console.error).toHaveBeenCalledWith('Failed to load conversation:', expect.any(Error))
-
+    expect(toastError).toHaveBeenCalledWith('select failed')
     getConversation.mockResolvedValueOnce({ messages: [] })
     await act(async () => firstChat.props.onClick())
     await flush()

--- a/frontend/app/(chat)/chat/[id]/page.test.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.test.tsx
@@ -315,20 +315,48 @@ describe('PublicChatPage', () => {
 
   test('prevents empty chat flash and preserves sidebar conversation items on refresh', async () => {
     query = new URLSearchParams('conversation=conv-1')
+    let resolveConversation!: (value: { messages: unknown[] }) => void
+    getConversation.mockImplementationOnce(() => new Promise((resolve) => { resolveConversation = resolve }))
+
     render()
     await flush()
 
-    // On initial load with conversation in URL, ChatContainer should receive loaded messages without key recreation
+    // While initial conversation load is pending, skeleton is rendered and no empty-chat welcome state appears
+    expect(renderer!.root.findAllByProps({ 'data-testid': 'chat-history-loading-skeleton' })).toHaveLength(1)
+    expect(output()).not.toContain('welcomeMessage')
+
+    // Resolve conversation load
+    await act(async () => {
+      resolveConversation({ messages: ['backend message'] })
+      await Promise.resolve()
+    })
+    await flush()
+
+    // ChatContainer is mounted with loaded messages and conversationId is updated
     expect(setConversationId).toHaveBeenCalledWith('conv-1')
-    expect(setMessages).toHaveBeenCalled()
+    expect(setMessages).toHaveBeenCalledWith([{ id: 'converted-0', role: 'user', content: 'backend message' }])
+    expect(renderer!.root.findAllByProps({ 'data-chat-container': true })).toHaveLength(1)
+    expect(output()).toContain('First chat')
+    expect(output()).toContain('untitledChat')
 
     // When onStreamEnd triggers refreshConversations with identical items
-    getConversations.mockResolvedValueOnce({ items: conversations, total: 2 })
+    let resolveRefresh!: (value: { items: typeof conversations; total: number }) => void
+    getConversations.mockImplementationOnce(() => new Promise((resolve) => { resolveRefresh = resolve }))
     await act(async () => {
       chatOptions.onStreamEnd?.()
       await Promise.resolve()
     })
+    await act(async () => {
+      resolveRefresh({ items: conversations, total: 2 })
+      await Promise.resolve()
+    })
+    await flush()
+
     expect(getConversations).toHaveBeenCalledTimes(2)
+    // Verify continuity of rendered sidebar entries
+    expect(output()).toContain('First chat')
+    expect(output()).toContain('untitledChat')
+    expect(renderer!.root.findAllByProps({ 'data-chat-container': true })).toHaveLength(1)
   })
 
   test('places the queued label in the conversation instead of below the composer', async () => {

--- a/frontend/app/(chat)/chat/[id]/page.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.tsx
@@ -124,7 +124,12 @@ export default function PublicChatPage({
   const [conversationPage, setConversationPage] = React.useState(1)
   const [hasMoreConversations, setHasMoreConversations] = React.useState(true)
   const [loadingMore, setLoadingMore] = React.useState(false)
-  const [loadingConversation, setLoadingConversation] = React.useState(false)
+  const [loadingConversation, setLoadingConversation] = React.useState(() => {
+    if (typeof window !== 'undefined') {
+      return Boolean(new URLSearchParams(window.location.search).get('conversation'))
+    }
+    return false
+  })
   const loadMoreRef = React.useRef<HTMLDivElement>(null)
   const suppressUrlConversationReloadRef = React.useRef(false)
 
@@ -184,7 +189,22 @@ export default function PublicChatPage({
     if (!resolvedParams) return
     try {
       const convData = await adapter.getConversations(resolvedParams.id, { page: 1, pageSize: 5 })
-      setConversations(convData.items)
+      setConversations((prev) => {
+        if (prev.length <= convData.items.length) {
+          if (
+            prev.length === convData.items.length &&
+            prev.every((item, idx) => item.id === convData.items[idx]?.id && item.title === convData.items[idx]?.title)
+          ) {
+            return prev
+          }
+          return convData.items
+        }
+        const updated = [...convData.items, ...prev.slice(convData.items.length)]
+        if (prev.every((item, idx) => item.id === updated[idx]?.id && item.title === updated[idx]?.title)) {
+          return prev
+        }
+        return updated
+      })
       setConversationPage(1)
       setHasMoreConversations(convData.items.length >= 5 && convData.total > convData.items.length)
     } catch {
@@ -406,10 +426,13 @@ export default function PublicChatPage({
   // Load conversation from URL parameter
   React.useEffect(() => {
     const loadConversationFromUrl = async () => {
-      if (embedMode || !resolvedParams || !agent || loadingConversations) return
+      if (embedMode || !resolvedParams || !agent) return
 
       const conversationParam = searchParams.get('conversation')
-      if (!conversationParam) return
+      if (!conversationParam) {
+        setLoadingConversation(false)
+        return
+      }
 
       if (suppressUrlConversationReloadRef.current) {
         suppressUrlConversationReloadRef.current = false
@@ -417,26 +440,52 @@ export default function PublicChatPage({
       }
 
       // Don't reload if already loaded
-      if (conversationParam === conversationId) return
+      if (conversationParam === conversationId) {
+        setLoadingConversation(false)
+        return
+      }
       setSelectedImageRefs([])
       dismissPreview()
 
       try {
         setLoadingConversation(true)
         const { messages: chatMessages } = await adapter.getConversation(conversationParam)
-        setMessages(chatMessages)
+        const snapshot = getStoredRunSnapshot(resolvedParams.id, conversationParam)
+        const lastMsg = chatMessages[chatMessages.length - 1]
+        const hasCompletedAssistantContent = Boolean(
+          lastMsg
+          && lastMsg.role === 'assistant'
+          && (
+            lastMsg.parts.some((p) => {
+              if (p.type === 'text') return Boolean(p.text && p.text.trim().length > 0)
+              if (p.type === 'reasoning') return Boolean(p.text && p.text.trim().length > 0)
+              if (p.type === 'tool-call' || p.type === 'mcp-tool-call') return true
+              if (p.type === 'tool-result' || p.type === 'mcp-tool-result') return true
+              return false
+            })
+            || lastMsg.metadata?.isError
+            || lastMsg.metadata?.isManuallyStopped
+          )
+        )
+        const needsPlaceholder = Boolean(snapshot && !hasCompletedAssistantContent)
+        const loadingMessages = needsPlaceholder
+          ? [...chatMessages, { id: `assistant-run-${snapshot!.runId}`, role: 'assistant' as const, parts: [], createdAt: new Date(), metadata: { isLoading: true } }]
+          : chatMessages
+        setMessages(loadingMessages)
         setConversationId(conversationParam)
       } catch (err) {
         console.error('Failed to load conversation from URL:', err)
         // If conversation not found, clear the URL parameter
         syncConversationUrl(null, 'replace')
+        const errorMessage = err instanceof Error && err.message ? err.message : t('loadConversationFailed')
+        toast.error(errorMessage)
       } finally {
         setLoadingConversation(false)
       }
     }
 
     loadConversationFromUrl()
-  }, [resolvedParams, agent, loadingConversations, searchParams, conversationId, setConversationId, setMessages, syncConversationUrl, adapter, embedMode, dismissPreview])
+  }, [resolvedParams, agent, searchParams, conversationId, setConversationId, setMessages, syncConversationUrl, adapter, embedMode, dismissPreview, t])
 
   // Load more conversations
   const loadMoreConversations = React.useCallback(async () => {
@@ -529,6 +578,8 @@ export default function PublicChatPage({
       syncConversationUrl(conv.id)
     } catch (err) {
       console.error('Failed to load conversation:', err)
+      const errorMessage = err instanceof Error && err.message ? err.message : t('loadConversationFailed')
+      toast.error(errorMessage)
     } finally {
       setLoadingConversation(false)
     }
@@ -1133,7 +1184,6 @@ export default function PublicChatPage({
           ) : (
             /* Messages using ChatContainer */
             <ChatContainer
-              key={conversationId ?? 'new-chat'}
               messages={messages}
               isStreaming={isStreaming}
               isLoading={chatLoading}

--- a/frontend/app/(chat)/chat/[id]/page.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.tsx
@@ -125,6 +125,7 @@ export default function PublicChatPage({
   const [hasMoreConversations, setHasMoreConversations] = React.useState(true)
   const [loadingMore, setLoadingMore] = React.useState(false)
   const [loadingConversation, setLoadingConversation] = React.useState(() => {
+    if (embedMode) return false
     if (typeof window !== 'undefined') {
       return Boolean(new URLSearchParams(window.location.search).get('conversation'))
     }
@@ -190,20 +191,19 @@ export default function PublicChatPage({
     try {
       const convData = await adapter.getConversations(resolvedParams.id, { page: 1, pageSize: 5 })
       setConversations((prev) => {
-        if (prev.length <= convData.items.length) {
-          if (
-            prev.length === convData.items.length &&
-            prev.every((item, idx) => item.id === convData.items[idx]?.id && item.title === convData.items[idx]?.title)
-          ) {
-            return prev
-          }
-          return convData.items
+        const incomingIds = new Set(convData.items.map((item) => item.id))
+        const remainingPrev = prev.filter((item) => !incomingIds.has(item.id))
+        let merged = [...convData.items, ...remainingPrev]
+        if (typeof convData.total === 'number' && convData.total >= 0 && merged.length > convData.total) {
+          merged = merged.slice(0, convData.total)
         }
-        const updated = [...convData.items, ...prev.slice(convData.items.length)]
-        if (prev.every((item, idx) => item.id === updated[idx]?.id && item.title === updated[idx]?.title)) {
+        if (
+          prev.length === merged.length &&
+          prev.every((item, idx) => item.id === merged[idx]?.id && item.title === merged[idx]?.title)
+        ) {
           return prev
         }
-        return updated
+        return merged
       })
       setConversationPage(1)
       setHasMoreConversations(convData.items.length >= 5 && convData.total > convData.items.length)

--- a/frontend/hooks/use-chat.test.ts
+++ b/frontend/hooks/use-chat.test.ts
@@ -1420,6 +1420,34 @@ describe('useChat', () => {
     expect(result.status).toBe('idle')
   })
 
+  it('preserves existing message references during history reload to prevent UI flicker', async () => {
+    const msg1: ChatMessage = { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hello' }] }
+    const msg2: ChatMessage = { id: 'm2', role: 'assistant', parts: [{ type: 'text', text: 'hi there' }] }
+    const initial = [msg1, msg2]
+    options = { agentId: 'agent-1', conversationId: 'conversation-1' }
+    renderHookHarness()
+    result.setConversationId('conversation-1')
+    result.setMessages(initial)
+    await flush()
+
+    // Server returns identical messages but in newly instantiated objects
+    const freshServerObjects: ChatMessage[] = [
+      { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hello' }] },
+      { id: 'm2', role: 'assistant', parts: [{ type: 'text', text: 'hi there' }] },
+    ]
+    getConversation.mockResolvedValue({ messages: freshServerObjects })
+    streamEvents = [{ event: 'message_start', data: { message_id: 'm3' } }, { event: 'message_end', data: {} }]
+    switchMessageVersion.mockResolvedValue(undefined)
+
+    // Trigger a history reload via switchVersion or editMessage
+    await result.switchVersion?.('m1', 0)
+    await flush()
+
+    // The message references must be preserved exactly
+    expect(result.messages[0]).toBe(msg1)
+    expect(result.messages[1]).toBe(msg2)
+  })
+
   it('marks edit-stream compression as errored when the stream fails', async () => {
     const userId = '11111111-1111-1111-1111-111111111111'
     const reloadStarted = deferred<void>()

--- a/frontend/hooks/use-chat.test.ts
+++ b/frontend/hooks/use-chat.test.ts
@@ -1421,8 +1421,14 @@ describe('useChat', () => {
   })
 
   it('preserves existing message references during history reload to prevent UI flicker', async () => {
-    const msg1: ChatMessage = { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hello' }] }
-    const msg2: ChatMessage = { id: 'm2', role: 'assistant', parts: [{ type: 'text', text: 'hi there' }] }
+    const msgId = '11111111-1111-1111-1111-111111111111'
+    const msg1: ChatMessage = { id: msgId, role: 'user', parts: [{ type: 'text', text: 'hello' }] }
+    const msg2: ChatMessage = {
+      id: '22222222-2222-2222-2222-222222222222',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'hi there' }],
+      metadata: { usage: { prompt_tokens: 10, total_tokens: 30 }, timing: { duration_ms: 50 } },
+    }
     const initial = [msg1, msg2]
     options = { agentId: 'agent-1', conversationId: 'conversation-1' }
     renderHookHarness()
@@ -1430,18 +1436,27 @@ describe('useChat', () => {
     result.setMessages(initial)
     await flush()
 
-    // Server returns identical messages but in newly instantiated objects
+    // Server returns identical messages and equivalent usage/timing metadata in freshly constructed objects
     const freshServerObjects: ChatMessage[] = [
-      { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hello' }] },
-      { id: 'm2', role: 'assistant', parts: [{ type: 'text', text: 'hi there' }] },
+      { id: msgId, role: 'user', parts: [{ type: 'text', text: 'hello' }] },
+      {
+        id: '22222222-2222-2222-2222-222222222222',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'hi there' }],
+        metadata: { usage: { prompt_tokens: 10, total_tokens: 30 }, timing: { duration_ms: 50 } },
+      },
     ]
     getConversation.mockResolvedValue({ messages: freshServerObjects })
-    streamEvents = [{ event: 'message_start', data: { message_id: 'm3' } }, { event: 'message_end', data: {} }]
+    getMessageVersions.mockResolvedValueOnce([{ id: 'v1' }])
     switchMessageVersion.mockResolvedValue(undefined)
 
-    // Trigger a history reload via switchVersion or editMessage
-    await result.switchVersion?.('m1', 0)
+    // Trigger a history reload via switchVersion
+    await result.switchVersion?.(msgId, 0)
     await flush()
+
+    expect(getMessageVersions).toHaveBeenCalledWith('agent-1', msgId)
+    expect(switchMessageVersion).toHaveBeenCalledWith('agent-1', msgId, 'v1')
+    expect(getConversation).toHaveBeenCalledWith('conversation-1')
 
     // The message references must be preserved exactly
     expect(result.messages[0]).toBe(msg1)

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -466,9 +466,12 @@ export function useChat(options: UseChatOptions): UseChatReturn {
     const { messages: convertedMessages } = await api.getConversation(targetConversationId)
     if (isCurrent && !isCurrent()) return
     const currentById = new Map(messagesRef.current.map((message) => [message.id, message]))
-    setMessages(convertedMessages.map((message) => {
+    const nextMessages = convertedMessages.map((message) => {
       const previous = currentById.get(message.id)
-      if (!previous?.metadata) return message
+      if (!previous?.metadata) {
+        if (previous && areChatMessagesEqual(previous, message)) return previous
+        return message
+      }
       const transientKeys = ['errorCode', 'errorMessage', 'preservedPartialProgress', 'isManuallyStopped', 'runInputState', 'runInputKind', 'runInputSequence']
       const transientMetadata = Object.fromEntries(
         transientKeys
@@ -479,10 +482,19 @@ export function useChat(options: UseChatOptions): UseChatReturn {
           .map((key) => [key, previous.metadata?.[key]])
       )
       if (previous.metadata.isError === true) transientMetadata.isError = true
-      return Object.keys(transientMetadata).length > 0
+      const resolvedMessage = Object.keys(transientMetadata).length > 0
         ? { ...message, metadata: { ...message.metadata, ...transientMetadata } }
         : message
-    }))
+      if (previous && areChatMessagesEqual(previous, resolvedMessage)) return previous
+      return resolvedMessage
+    })
+    if (
+      nextMessages.length === messagesRef.current.length &&
+      nextMessages.every((msg, idx) => msg === messagesRef.current[idx])
+    ) {
+      return
+    }
+    setMessages(nextMessages)
   }, [api])
 
   const notifyStreamEnd = useCallback((session: AssistantStreamSession) => {
@@ -1822,6 +1834,30 @@ export function removeRunSnapshot(agentId: string, conversationId: string) {
   } catch {
     // The run still remains recoverable while this hook instance is mounted.
   }
+}
+
+function areChatMessagesEqual(a: ChatMessage, b: ChatMessage): boolean {
+  if (a === b) return true
+  if (a.id !== b.id || a.role !== b.role) return false
+  if (a.versionNumber !== b.versionNumber || a.versionCount !== b.versionCount) return false
+  if (a.parts.length !== b.parts.length) return false
+  for (let i = 0; i < a.parts.length; i++) {
+    const partA = a.parts[i]
+    const partB = b.parts[i]
+    if (partA.type !== partB.type) return false
+    if (JSON.stringify(partA) !== JSON.stringify(partB)) return false
+  }
+  const metaA = a.metadata
+  const metaB = b.metadata
+  if (!metaA && !metaB) return true
+  if (!metaA || !metaB) return false
+  const keysA = Object.keys(metaA)
+  const keysB = Object.keys(metaB)
+  if (keysA.length !== keysB.length) return false
+  for (const key of keysA) {
+    if (metaA[key] !== metaB[key]) return false
+  }
+  return true
 }
 
 function createRunInputRequestId(): string {

--- a/frontend/hooks/use-chat.ts
+++ b/frontend/hooks/use-chat.ts
@@ -1855,7 +1855,14 @@ function areChatMessagesEqual(a: ChatMessage, b: ChatMessage): boolean {
   const keysB = Object.keys(metaB)
   if (keysA.length !== keysB.length) return false
   for (const key of keysA) {
-    if (metaA[key] !== metaB[key]) return false
+    const valA = metaA[key]
+    const valB = metaB[key]
+    if (valA === valB) continue
+    if (typeof valA === 'object' && valA !== null && typeof valB === 'object' && valB !== null) {
+      if (JSON.stringify(valA) !== JSON.stringify(valB)) return false
+    } else {
+      return false
+    }
   }
   return true
 }

--- a/frontend/i18n/en/publicChat.json
+++ b/frontend/i18n/en/publicChat.json
@@ -30,6 +30,7 @@
     "deleteConversationDescription": "Are you sure you want to delete conversation \"{title}\"? This action cannot be undone.",
     "confirmDeleteConversation": "Confirm Delete",
     "deleteConversationFailed": "Failed to delete conversation. Please try again.",
+    "loadConversationFailed": "Failed to load conversation. Please try again.",
     "conversationTitle": "Title",
     "conversationTitlePlaceholder": "Enter conversation title...",
     "cancel": "Cancel",

--- a/frontend/i18n/types/publicChat.ts
+++ b/frontend/i18n/types/publicChat.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-09-07T05:56:54.044Z
+// GENERATED — 2026-09-08T18:19:38.410Z
 // Source: i18n/en/publicChat.json
 export type PublicChatMessages = {
   publicChat: {
@@ -32,6 +32,7 @@ export type PublicChatMessages = {
     deleteConversationDescription: string
     confirmDeleteConversation: string
     deleteConversationFailed: string
+    loadConversationFailed: string
     conversationTitle: string
     conversationTitlePlaceholder: string
     cancel: string

--- a/frontend/i18n/zh/publicChat.json
+++ b/frontend/i18n/zh/publicChat.json
@@ -30,6 +30,7 @@
     "deleteConversationDescription": "确定要删除对话“{title}”吗？此操作无法撤销。",
     "confirmDeleteConversation": "确认删除",
     "deleteConversationFailed": "删除对话失败，请稍后重试。",
+    "loadConversationFailed": "加载对话失败，请稍后重试。",
     "conversationTitle": "标题",
     "conversationTitlePlaceholder": "输入对话标题...",
     "cancel": "取消",


### PR DESCRIPTION
## Description

This PR fixes two usability issues in the Agent chat surface:
1. **Chat history list flickering on refresh / reload**:
   - Resolved the initial render race where `loadingConversation` defaulted to `false` while loading an existing conversation from URL parameter, which caused a transient flash of the empty welcome state before transitioning to the loading skeleton.
   - Removed redundant `key={conversationId ?? 'new-chat'}` on `<ChatContainer />`. `ChatContainer` already internally handles layout effects and scroll positioning across conversation changes; forcing React to destroy and recreate the container DOM caused unnecessary layout reflows and flickering.
   - Preserved identical message object references in `reloadConversationMessages` (`useChat`) via deep comparison (`areChatMessagesEqual`). This ensures `React.memo(ChatMessageRow)` hits its memoization cache on history reloads (e.g. after stream end or version switches), avoiding re-parsing unchanged Markdown, code blocks, and KaTeX.
   - Stabilized `refreshConversations` by preventing state updates when conversation items and titles have not changed, stopping spurious teardowns of the background run status polling effect.
2. **Missing user toast notification when a conversation fails to load**:
   - Added `toast.error(errorMessage)` in `loadConversationFromUrl` and `handleSelectConversation` error catch blocks so API errors (such as 404 `Conversation not found` / `对话未找到`) surface clearly to users instead of silently logging to console and clearing the URL.
   - Added `loadConversationFailed` bilingual i18n keys to `zh/publicChat.json` and `en/publicChat.json` with regenerated types.

## Changes

- `frontend/app/(chat)/chat/[id]/page.tsx`:
  - Initialize `loadingConversation` based on whether `conversation` query param is present.
  - Unblock `loadConversationFromUrl` from `loadingConversations`.
  - Remove `key={conversationId ?? 'new-chat'}` from `<ChatContainer />`.
  - Deduplicate `setConversations` in `refreshConversations`.
  - Show error toast using `err.message` or `t('loadConversationFailed')` on conversation load errors.
- `frontend/hooks/use-chat.ts`:
  - Compare incoming messages against current messages in `reloadConversationMessages` using `areChatMessagesEqual`.
  - Preserve message object references and skip `setMessages` if entire array is unchanged.
- `frontend/i18n/{en,zh}/publicChat.json` & `frontend/i18n/types/publicChat.ts`:
  - Added bilingual `loadConversationFailed` dictionary entry.
- Tests:
  - `frontend/app/(chat)/chat/[id]/page.test.tsx`: Added regression coverage for flicker-free conversation refresh and toast error reporting.
  - `frontend/hooks/use-chat.test.ts`: Added unit test verifying message reference preservation on history reload.

## Verification

- `bun test --isolate ./app/(chat)/chat/[id]/page.test.tsx ./hooks/use-chat.test.ts` (70 pass, 0 fail)
- `bun run i18n:lint` (All checks passed)
- `bun x tsc --noEmit` (0 errors)
- `bun run lint` (0 errors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty-chat flashes when loading conversations from a URL.
  * Preserved sidebar conversations when refreshing conversation data.
  * Added error notifications when conversations fail to load or select.
  * Preserved chat messages during history reloads to reduce unnecessary UI flicker.

* **Localization**
  * Added conversation-loading error messages in English and Chinese.

* **Tests**
  * Added coverage for URL loading, sidebar refresh behavior, error notifications, and message preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->