### PR TITLE
fix(workflow): prevent SSRF in HTTP request node executor (YUN-150)

### DIFF
--- a/backend/app/core/network_security.py
+++ b/backend/app/core/network_security.py
@@ -8,10 +8,13 @@ _BLOCKED_HOSTS = {"localhost", "local", "metadata.google.internal"}
 
 
 class _ValidatedExternalUrl(str):
+    """Marker string type representing a validated external URL."""
+
     pass
 
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Check whether the provided IP address is in a reserved, private, or local range."""
     return any(
         (
             ip.is_private,
@@ -25,6 +28,7 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
 
 
 def validate_external_http_url(value: str, getaddrinfo=None) -> _ValidatedExternalUrl:
+    """Validate an external HTTP/HTTPS URL against blocked hosts, private IPs, and metadata targets."""
     if getaddrinfo is None:
         getaddrinfo = socket.getaddrinfo
     parsed = urlparse(value)

--- a/backend/app/core/network_security.py
+++ b/backend/app/core/network_security.py
@@ -1,0 +1,53 @@
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from app.schemas.response import BusinessError
+
+_BLOCKED_HOSTS = {"localhost", "local", "metadata.google.internal"}
+
+
+class _ValidatedExternalUrl(str):
+    pass
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return any(
+        (
+            ip.is_private,
+            ip.is_loopback,
+            ip.is_link_local,
+            ip.is_reserved,
+            ip.is_multicast,
+            ip.is_unspecified,
+        )
+    )
+
+
+def validate_external_http_url(value: str, getaddrinfo=None) -> _ValidatedExternalUrl:
+    if getaddrinfo is None:
+        getaddrinfo = socket.getaddrinfo
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise BusinessError(msg_key="http_tool_url_invalid")
+    host = parsed.hostname.lower().rstrip(".")
+    if host in _BLOCKED_HOSTS:
+        raise BusinessError(msg_key="http_tool_url_host_not_allowed")
+    try:
+        port = parsed.port
+    except ValueError:
+        raise BusinessError(msg_key="http_tool_url_invalid")
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+    if ip and _is_blocked_ip(ip):
+        raise BusinessError(msg_key="http_tool_url_host_not_allowed")
+    try:
+        resolved = getaddrinfo(host, port or None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise BusinessError(msg_key="http_tool_url_host_cannot_be_resolved") from exc
+    for *_, sockaddr in resolved:
+        if _is_blocked_ip(ipaddress.ip_address(sockaddr[0])):
+            raise BusinessError(msg_key="http_tool_url_host_not_allowed")
+    return _ValidatedExternalUrl(value)

--- a/backend/app/llm/tools/executors.py
+++ b/backend/app/llm/tools/executors.py
@@ -4,69 +4,32 @@
 提供 HTTP 工具和代码工具的执行功能，供 API 端点复用。
 """
 
-import ipaddress
 import json
 import logging
 import mimetypes
 import re
-import socket
 from base64 import b64decode
 from typing import Any
-from urllib.parse import urlparse
+import socket
 
 import httpx
 
 from app.core.i18n import t
+from app.core.network_security import (
+    _ValidatedExternalUrl,
+    validate_external_http_url,
+)
 from app.schemas.response import BusinessError
 
 logger = logging.getLogger(__name__)
 
-_BLOCKED_HOSTS = {"localhost", "local", "metadata.google.internal"}
 _UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\}\}")
 
-
-class _ValidatedExternalUrl(str):
-    pass
-
-
-def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    return any(
-        (
-            ip.is_private,
-            ip.is_loopback,
-            ip.is_link_local,
-            ip.is_reserved,
-            ip.is_multicast,
-            ip.is_unspecified,
-        )
-    )
+__all__ = ["socket"]
 
 
 def _validate_external_http_url(value: str) -> _ValidatedExternalUrl:
-    parsed = urlparse(value)
-    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-        raise BusinessError(msg_key="http_tool_url_invalid")
-    host = parsed.hostname.lower().rstrip(".")
-    if host in _BLOCKED_HOSTS:
-        raise BusinessError(msg_key="http_tool_url_host_not_allowed")
-    try:
-        port = parsed.port
-    except ValueError:
-        raise BusinessError(msg_key="http_tool_url_invalid")
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        ip = None
-    if ip and _is_blocked_ip(ip):
-        raise BusinessError(msg_key="http_tool_url_host_not_allowed")
-    try:
-        resolved = socket.getaddrinfo(host, port or None, type=socket.SOCK_STREAM)
-    except socket.gaierror as exc:
-        raise BusinessError(msg_key="http_tool_url_host_cannot_be_resolved") from exc
-    for *_, sockaddr in resolved:
-        if _is_blocked_ip(ipaddress.ip_address(sockaddr[0])):
-            raise BusinessError(msg_key="http_tool_url_host_not_allowed")
-    return _ValidatedExternalUrl(value)
+    return validate_external_http_url(value, getaddrinfo=socket.getaddrinfo)
 
 
 def _strip_unresolved_placeholders(value: str) -> str:

--- a/backend/app/services/workflow/executors/tool.py
+++ b/backend/app/services/workflow/executors/tool.py
@@ -4,9 +4,11 @@ Tool and agent node executors.
 Handles external tool calls and agent invocations.
 """
 
-from typing import TYPE_CHECKING, Any
-import logging
+import asyncio
 import json
+import logging
+from typing import TYPE_CHECKING, Any
+
 from app.core.network_security import validate_external_http_url
 from app.schemas.response import BusinessError
 from app.services.error_messages import resolve_user_visible_error
@@ -448,7 +450,7 @@ class HTTPRequestNodeExecutor(NodeExecutor):
         # Resolve templates
         url = await self._resolve_template(url_template, context)
         try:
-            validated_url = validate_external_http_url(url)
+            validated_url = await asyncio.to_thread(validate_external_http_url, url)
         except BusinessError as exc:
             return ExecutionResult(error=resolve_user_visible_error(str(exc)))
         except ValueError as exc:

--- a/backend/app/services/workflow/executors/tool.py
+++ b/backend/app/services/workflow/executors/tool.py
@@ -7,7 +7,8 @@ Handles external tool calls and agent invocations.
 from typing import TYPE_CHECKING, Any
 import logging
 import json
-
+from app.core.network_security import validate_external_http_url
+from app.schemas.response import BusinessError
 from app.services.error_messages import resolve_user_visible_error
 
 from ..executor import NodeExecutor, NodeExecutorRegistry, ExecutionResult
@@ -446,6 +447,12 @@ class HTTPRequestNodeExecutor(NodeExecutor):
 
         # Resolve templates
         url = await self._resolve_template(url_template, context)
+        try:
+            validated_url = validate_external_http_url(url)
+        except BusinessError as exc:
+            return ExecutionResult(error=resolve_user_visible_error(str(exc)))
+        except ValueError as exc:
+            return ExecutionResult(error=resolve_user_visible_error(str(exc)))
         headers: dict[str, str] = {}
         for key, value in headers_template.items():
             headers[key] = await self._resolve_template(str(value), context)
@@ -462,7 +469,7 @@ class HTTPRequestNodeExecutor(NodeExecutor):
             async with httpx.AsyncClient(timeout=timeout) as client:
                 response = await client.request(
                     method=method,
-                    url=url,
+                    url=validated_url,
                     headers=headers,
                     json=body if isinstance(body, dict) else None,
                     content=body if isinstance(body, str) else None,

--- a/backend/tests/core/test_network_security.py
+++ b/backend/tests/core/test_network_security.py
@@ -1,0 +1,69 @@
+import ipaddress
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from app.core.network_security import (
+    _is_blocked_ip,
+    validate_external_http_url,
+)
+from app.schemas.response import BusinessError
+
+
+def test_is_blocked_ip_covers_all_types():
+    assert _is_blocked_ip(ipaddress.ip_address("127.0.0.1")) is True
+    assert _is_blocked_ip(ipaddress.ip_address("10.0.0.1")) is True
+    assert _is_blocked_ip(ipaddress.ip_address("169.254.1.1")) is True
+    assert _is_blocked_ip(ipaddress.ip_address("224.0.0.1")) is True
+    assert _is_blocked_ip(ipaddress.ip_address("0.0.0.0")) is True
+    assert _is_blocked_ip(ipaddress.ip_address("240.0.0.1")) is True
+    assert _is_blocked_ip(ipaddress.ip_address("8.8.8.8")) is False
+
+    # IPv6
+    assert _is_blocked_ip(ipaddress.ip_address("::1")) is True
+    assert _is_blocked_ip(ipaddress.ip_address("fe80::1")) is True
+    assert _is_blocked_ip(ipaddress.ip_address("2001:4860:4860::8888")) is False
+
+
+@pytest.mark.parametrize(
+    "url,error",
+    [
+        ("not_a_url", "http_tool_url_invalid"),
+        ("ftp://example.com", "http_tool_url_invalid"),
+        ("http://", "http_tool_url_invalid"),
+        ("https://example.com:badport", "http_tool_url_invalid"),
+        ("http://localhost", "http_tool_url_host_not_allowed"),
+        ("http://local", "http_tool_url_host_not_allowed"),
+        ("http://metadata.google.internal", "http_tool_url_host_not_allowed"),
+        ("http://127.0.0.1", "http_tool_url_host_not_allowed"),
+        ("http://169.254.169.254", "http_tool_url_host_not_allowed"),
+        ("http://[::1]", "http_tool_url_host_not_allowed"),
+    ],
+)
+def test_validate_external_http_url_rejections(url, error):
+    with pytest.raises(BusinessError) as exc_info:
+        validate_external_http_url(url)
+    assert exc_info.value.msg_key == error
+
+
+def test_validate_external_http_url_dns_resolution():
+    with patch("socket.getaddrinfo", side_effect=socket.gaierror):
+        with pytest.raises(BusinessError) as exc_info:
+            validate_external_http_url("https://unresolvable.invalid")
+        assert exc_info.value.msg_key == "http_tool_url_host_cannot_be_resolved"
+
+    # Resolved to private IP
+    private_sock = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.1", 443))]
+    with patch("socket.getaddrinfo", return_value=private_sock):
+        with pytest.raises(BusinessError) as exc_info:
+            validate_external_http_url("https://public-site.com")
+        assert exc_info.value.msg_key == "http_tool_url_host_not_allowed"
+
+    # Resolved to public IP
+    public_sock = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+    with patch("socket.getaddrinfo", return_value=public_sock):
+        assert (
+            validate_external_http_url("https://public-site.com")
+            == "https://public-site.com"
+        )

--- a/backend/tests/services/workflow/test_tool_executor_behavior.py
+++ b/backend/tests/services/workflow/test_tool_executor_behavior.py
@@ -1,6 +1,7 @@
 """Behavioral tests for agent and HTTP workflow executors."""
 
 import json
+import socket
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -579,10 +580,14 @@ class TestHTTPRequestNodeExecutorBehavior:
                 }
             }
         }
-
-        with patch("httpx.AsyncClient", return_value=client_context) as client_class:
+        with (
+            patch(
+                "app.services.workflow.executors.tool.validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
+            patch("httpx.AsyncClient", return_value=client_context) as client_class,
+        ):
             result = await HTTPRequestNodeExecutor().execute(node, context, run)
-
         client_class.assert_called_once_with(timeout=5)
         client.request.assert_awaited_once_with(
             method="POST",
@@ -610,8 +615,13 @@ class TestHTTPRequestNodeExecutorBehavior:
         client.request.return_value = response
         client_context = AsyncMock()
         client_context.__aenter__.return_value = client
-
-        with patch("httpx.AsyncClient", return_value=client_context):
+        with (
+            patch(
+                "app.services.workflow.executors.tool.validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
+            patch("httpx.AsyncClient", return_value=client_context),
+        ):
             result = await HTTPRequestNodeExecutor().execute(
                 {
                     "data": {
@@ -642,6 +652,10 @@ class TestHTTPRequestNodeExecutorBehavior:
         client_context.__aenter__.return_value = client
 
         with (
+            patch(
+                "app.services.workflow.executors.tool.validate_external_http_url",
+                side_effect=lambda value: value,
+            ),
             patch("httpx.AsyncClient", return_value=client_context),
             patch(
                 "app.services.workflow.executors.tool.resolve_user_visible_error",
@@ -663,6 +677,77 @@ class TestHTTPRequestNodeExecutorBehavior:
         assert missing_url.error == "tool_execution_failed"
         assert timeout.error == "public: Request timed out after 2s"
         assert request_error.error == "public: bad request"
+
+    @pytest.mark.anyio
+    async def test_execute_blocks_ssrf_destinations(self, context, run):
+        executor = HTTPRequestNodeExecutor()
+
+        # AWS IMDSv1
+        result_aws = await executor.execute(
+            {"data": {"config": {"url": "http://169.254.169.254/latest/meta-data/"}}},
+            context,
+            run,
+        )
+        assert result_aws.error == "HTTP URL host is not allowed"
+
+        # Loopback
+        result_loopback = await executor.execute(
+            {"data": {"config": {"url": "http://127.0.0.1:8000/internal"}}},
+            context,
+            run,
+        )
+        assert result_loopback.error == "HTTP URL host is not allowed"
+
+        # Localhost name
+        result_localhost = await executor.execute(
+            {"data": {"config": {"url": "http://localhost/admin"}}},
+            context,
+            run,
+        )
+        assert result_localhost.error == "HTTP URL host is not allowed"
+
+        # GCP metadata hostname
+        result_gcp = await executor.execute(
+            {
+                "data": {
+                    "config": {
+                        "url": "http://metadata.google.internal/computeMetadata/v1/"
+                    }
+                }
+            },
+            context,
+            run,
+        )
+        assert result_gcp.error == "HTTP URL host is not allowed"
+
+        # Invalid scheme
+        result_ftp = await executor.execute(
+            {"data": {"config": {"url": "ftp://example.com/file"}}},
+            context,
+            run,
+        )
+        assert result_ftp.error == "Invalid HTTP URL"
+
+        # Unresolvable host
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror):
+            result_unresolved = await executor.execute(
+                {"data": {"config": {"url": "https://nonexistent.domain.invalid"}}},
+                context,
+                run,
+            )
+            assert result_unresolved.error == "HTTP URL host cannot be resolved"
+
+        # DNS rebinding to private IP
+        private_sockaddr = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 443))
+        ]
+        with patch("socket.getaddrinfo", return_value=private_sockaddr):
+            result_rebind = await executor.execute(
+                {"data": {"config": {"url": "https://public-looking-domain.com"}}},
+                context,
+                run,
+            )
+            assert result_rebind.error == "HTTP URL host is not allowed"
 
     def test_output_metadata(self):
         executor = HTTPRequestNodeExecutor()


### PR DESCRIPTION
## Summary
Fixes SSRF vulnerability in the workflow HTTP Request node executor (`HTTPRequestNodeExecutor`) as tracked in Linear issue **YUN-150** / GitHub issue #426.

Previously, `HTTPRequestNodeExecutor` performed HTTP requests directly via `httpx.AsyncClient` without destination host or IP address validation, allowing authenticated users to query internal networks, loopback services (`127.0.0.1`, `localhost`), and cloud metadata endpoints (such as AWS IMDSv1 at `169.254.169.254` and GCP metadata).

## Key Changes
1. **Shared Network Security Validation (`app.core.network_security`)**:
   - Extracted destination validation logic into `validate_external_http_url` and `_is_blocked_ip`.
   - Validates schemes (HTTP/HTTPS only), hostname validity, blocked hosts (`localhost`, `local`, `metadata.google.internal`), and IP ranges (private, loopback, link-local, reserved, multicast, unspecified).
   - Resolves host DNS to prevent SSRF via DNS rebinding to internal or cloud metadata IPs.
2. **Workflow HTTP Request Node Protection (`app.services.workflow.executors.tool`)**:
   - In `HTTPRequestNodeExecutor.execute`, validates the resolved URL using `validate_external_http_url` before initiating any HTTP connection.
   - Surfaces user-friendly, localized errors (`http_tool_url_host_not_allowed`, `http_tool_url_invalid`, `http_tool_url_host_cannot_be_resolved`) if validation fails.
3. **HTTP Tool Executor Refactor (`app.llm.tools.executors`)**:
   - Refactored `_validate_external_http_url` to delegate to the shared `validate_external_http_url` utility while preserving backward-compatibility with tests.
4. **Comprehensive Test Suite**:
   - Added `backend/tests/core/test_network_security.py` covering all blocked IP ranges, invalid schemes, host blocklists, and DNS resolution behaviors.
   - Added SSRF test cases in `backend/tests/services/workflow/test_tool_executor_behavior.py` covering AWS IMDSv1, loopback, localhost, GCP metadata, non-HTTP schemes, and DNS rebinding to private IPs.

## Verification
- `ruff format --check` and `ruff check`: passed.
- Full backend pytest suite: 7059 passed, 3 skipped.
- Backend coverage gate:
  - Line coverage: **96.86%** (required $\ge 95.00\%$)
  - Branch coverage: **95.08%** (required $\ge 95.00\%$)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for external HTTP(S) URLs.
  - Blocks invalid schemes, restricted hostnames, malformed ports, private addresses, and unsafe DNS resolutions.
  - Prevents workflow HTTP requests from targeting unsafe destinations and provides user-visible error messages.

- **Bug Fixes**
  - Strengthened protection against SSRF attempts, including metadata-service and DNS-rebinding destinations.

- **Tests**
  - Added coverage for blocked and permitted IPv4/IPv6 addresses, malformed URLs, DNS failures, and unsafe workflow requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->