### PR TITLE
fix(stats): close YUN-153 review findings (IDOR gap, index runbook, stats correctness)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,31 @@
+# CodeRabbit configuration.
+#
+# Only the docstring pre-merge check is configured; every other setting uses
+# CodeRabbit's defaults.
+reviews:
+  pre_merge_checks:
+    docstrings:
+      # Disabled deliberately, not because docstrings are unwelcome but because
+      # this threshold measures something the project does not track.
+      #
+      # The default 80% bar is far above what this codebase achieves, and the
+      # check is scoped to functions the diff touches (so any PR adding test
+      # helpers is penalised hardest):
+      #
+      #   backend/app    docstring coverage: 51.4% (1499/2916 functions)
+      #   backend/tests  docstring coverage:  2.5%  (216/8668 functions)
+      #
+      # ruff is configured without the `D` docstring rules
+      # (pyproject.toml: select = ["E4", "E7", "E9", "F"]), so the linter does
+      # not ask for docstrings either. The check therefore reports a gap that
+      # nothing else in the toolchain recognises, and one PR cannot close it.
+      #
+      # Measurements and the discussion that led here:
+      # https://github.com/clouisle/Clouisle/pull/440#issuecomment-5646176154
+      #
+      # Re-enable with mode "warning" (or "error") if the project decides to
+      # adopt a docstring standard repo-wide; raise `threshold` alongside it to
+      # a value the codebase actually meets.
+      #
+      # Quoted: bare `off` is YAML 1.1 boolean false, not the enum string.
+      mode: "off"

--- a/backend/app/api/v1/endpoints/agent_stats.py
+++ b/backend/app/api/v1/endpoints/agent_stats.py
@@ -13,6 +13,7 @@ from app.api import deps
 from app.api.v1.endpoints.agents import check_agent_access
 from app.api.v1.endpoints.chat import get_tool_display_names
 from app.core.config import settings
+from app.core.db_limits import run_bounded
 from app.core.i18n import resolve_language
 from app.models.user import User
 from app.schemas.response import success
@@ -20,17 +21,6 @@ from app.services import stats_sql
 from app.core.timezone import now, to_utc
 
 router = APIRouter()
-
-# One semaphore per process, shared by every statistics request. Bounding the
-# fan-out keeps a single request from occupying the whole connection pool while
-# its own queries queue behind it; separate requests still interleave.
-_AGGREGATE_SEMAPHORE = asyncio.Semaphore(settings.DB_AGGREGATE_CONCURRENCY)
-
-
-async def _run_aggregate(coro: Any) -> Any:
-    """Run one aggregation without holding more than the configured budget."""
-    async with _AGGREGATE_SEMAPHORE:
-        return await coro
 
 
 def _resolve_tool_display_name(name: str, display_names: dict[str, str]) -> str:
@@ -86,11 +76,11 @@ async def get_agent_stats(
         latency,
         interventions,
     ) = await asyncio.gather(
-        _run_aggregate(stats_sql.agent_conversation_overview(agent_id, start_time)),
-        _run_aggregate(stats_sql.agent_message_overview(agent_id, start_time)),
-        _run_aggregate(stats_sql.agent_run_health(agent_id, start_time)),
-        _run_aggregate(stats_sql.agent_latency_percentiles(agent_id, start_time)),
-        _run_aggregate(stats_sql.agent_intervention_counts(agent_id, start_time)),
+        run_bounded(stats_sql.agent_conversation_overview(agent_id, start_time)),
+        run_bounded(stats_sql.agent_message_overview(agent_id, start_time)),
+        run_bounded(stats_sql.agent_run_health(agent_id, start_time)),
+        run_bounded(stats_sql.agent_latency_percentiles(agent_id, start_time)),
+        run_bounded(stats_sql.agent_intervention_counts(agent_id, start_time)),
     )
 
     total_conversations = conversations["total_conversations"]

--- a/backend/app/api/v1/endpoints/agent_stats.py
+++ b/backend/app/api/v1/endpoints/agent_stats.py
@@ -14,7 +14,6 @@ from app.api.v1.endpoints.agents import check_agent_access
 from app.api.v1.endpoints.chat import get_tool_display_names
 from app.core.config import settings
 from app.core.i18n import resolve_language
-from app.models.agent import Conversation
 from app.models.user import User
 from app.schemas.response import success
 from app.services import stats_sql
@@ -274,43 +273,3 @@ async def get_agent_tool_usage(
             "total_calls": sum(int(t["count"]) for t in sorted_tools),
         }
     )
-
-
-@router.get("/{agent_id}/stats/recent-conversations")
-async def get_recent_conversations(
-    agent_id: UUID,
-    limit: int = Query(10, ge=1, le=50),
-    current_user: User = Depends(deps.get_current_active_user),
-) -> Any:
-    """
-    Get recent conversations for the agent.
-    """
-    await check_agent_access(agent_id, current_user)
-
-    conversations = (
-        await Conversation.filter(agent_id=agent_id)
-        .order_by("-updated_at")
-        .limit(limit)
-        .prefetch_related("user")
-    )
-
-    result = []
-    for conv in conversations:
-        result.append(
-            {
-                "id": str(conv.id),
-                "title": conv.title,
-                "user": {
-                    "id": str(conv.user.id),
-                    "username": conv.user.username,
-                }
-                if conv.user
-                else None,
-                "message_count": conv.message_count,
-                "token_usage": conv.token_usage,
-                "created_at": conv.created_at.isoformat(),
-                "updated_at": conv.updated_at.isoformat(),
-            }
-        )
-
-    return success(data=result)

--- a/backend/app/api/v1/endpoints/agent_stats.py
+++ b/backend/app/api/v1/endpoints/agent_stats.py
@@ -22,6 +22,17 @@ from app.core.timezone import now, to_utc
 
 router = APIRouter()
 
+# One semaphore per process, shared by every statistics request. Bounding the
+# fan-out keeps a single request from occupying the whole connection pool while
+# its own queries queue behind it; separate requests still interleave.
+_AGGREGATE_SEMAPHORE = asyncio.Semaphore(settings.DB_AGGREGATE_CONCURRENCY)
+
+
+async def _run_aggregate(coro: Any) -> Any:
+    """Run one aggregation without holding more than the configured budget."""
+    async with _AGGREGATE_SEMAPHORE:
+        return await coro
+
 
 def _resolve_tool_display_name(name: str, display_names: dict[str, str]) -> str:
     """Resolve one observed tool name to a human-readable label.
@@ -67,7 +78,8 @@ async def get_agent_stats(
     # Both helpers aggregate in the database; the previous implementation ran
     # six counts and pulled every token_usage / tool_calls JSON payload plus
     # every user_id into Python. The five aggregations are independent, so they
-    # run concurrently rather than as five sequential round trips.
+    # run concurrently rather than as five sequential round trips — bounded by
+    # the shared semaphore so one request cannot monopolise the pool.
     (
         conversations,
         messages,
@@ -75,11 +87,11 @@ async def get_agent_stats(
         latency,
         interventions,
     ) = await asyncio.gather(
-        stats_sql.agent_conversation_overview(agent_id, start_time),
-        stats_sql.agent_message_overview(agent_id, start_time),
-        stats_sql.agent_run_health(agent_id, start_time),
-        stats_sql.agent_latency_percentiles(agent_id, start_time),
-        stats_sql.agent_intervention_counts(agent_id, start_time),
+        _run_aggregate(stats_sql.agent_conversation_overview(agent_id, start_time)),
+        _run_aggregate(stats_sql.agent_message_overview(agent_id, start_time)),
+        _run_aggregate(stats_sql.agent_run_health(agent_id, start_time)),
+        _run_aggregate(stats_sql.agent_latency_percentiles(agent_id, start_time)),
+        _run_aggregate(stats_sql.agent_intervention_counts(agent_id, start_time)),
     )
 
     total_conversations = conversations["total_conversations"]
@@ -142,42 +154,51 @@ async def get_agent_trends(
 
     now_local = now()
 
-    # Determine granularity and range based on period
+    # Determine granularity and count based on period
     if period == "24h":
-        start_time = now_local - timedelta(hours=24)
         granularity = "hour"
         num_points = 24
     elif period == "7d":
-        start_time = now_local - timedelta(days=7)
         granularity = "day"
         num_points = 7
     else:  # 30d
-        start_time = now_local - timedelta(days=30)
         granularity = "day"
         num_points = 30
 
-    start_time_utc = to_utc(start_time)
+    # Build the clock-aligned point grid FIRST, then derive the query window
+    # from its earliest point. Deriving the window independently (e.g. now-24h
+    # at 12:37 while the first hourly point is 13:00) made the window start
+    # mid-bucket: rows in that leading partial bucket were fetched, bucketed to
+    # a key that is never rendered, and silently discarded by the lookup below.
+    if granularity == "hour":
+        first_point = now_local.replace(minute=0, second=0, microsecond=0) - timedelta(
+            hours=num_points - 1
+        )
+        point_starts = [
+            first_point + timedelta(hours=index) for index in range(num_points)
+        ]
+    else:
+        first_date = (now_local - timedelta(days=num_points - 1)).date()
+        point_starts = [
+            datetime.combine(
+                first_date + timedelta(days=index), datetime.min.time()
+            ).replace(tzinfo=now_local.tzinfo)
+            for index in range(num_points)
+        ]
 
     # Bucket in the database on local-time boundaries. The previous loop
     # rescanned every loaded row once per point (O(points x rows)).
     buckets = await stats_sql.agent_trend_buckets(
-        agent_id, start_time_utc, granularity, settings.TIMEZONE
+        agent_id, to_utc(point_starts[0]), granularity, settings.TIMEZONE
     )
 
     data_points = []
-    for i in range(num_points):
-        if granularity == "hour":
-            point_start = now_local.replace(
-                minute=0, second=0, microsecond=0
-            ) - timedelta(hours=num_points - 1 - i)
-            label = point_start.strftime("%H:00")
-        else:
-            point_date = (now_local - timedelta(days=num_points - i - 1)).date()
-            point_start = datetime.combine(point_date, datetime.min.time()).replace(
-                tzinfo=now_local.tzinfo
-            )
-            label = point_date.strftime("%m/%d")
-
+    for point_start in point_starts:
+        label = (
+            point_start.strftime("%H:00")
+            if granularity == "hour"
+            else point_start.strftime("%m/%d")
+        )
         bucket = buckets.get(point_start.replace(tzinfo=None), {})
         data_points.append(
             {

--- a/backend/app/api/workflow_access.py
+++ b/backend/app/api/workflow_access.py
@@ -64,11 +64,16 @@ async def check_workflow_access(
     if workflow.visibility == WorkflowVisibility.PRIVATE:
         if is_owner:
             return workflow
-        if require_write:
-            await check_team_access(workflow.team.id, user, require_admin=True)
-            return workflow
+        # PRIVATE means "only the creator can access", so a non-owner is
+        # rejected for writes too. A team admin is not a creator: allowing the
+        # write here would let an admin modify a workflow that the list and
+        # stats scope (workflow_read_visibility_filter) deliberately hides from
+        # them, i.e. an IDOR reachable only by guessing the id. This mirrors
+        # check_agent_access, which refuses a non-owner's write outright.
         if not workflow.created_by:
-            await check_team_access(workflow.team.id, user)
+            # Creator-less legacy row: no owner exists to protect, so fall back
+            # to team scope and require admin for writes.
+            await check_team_access(workflow.team.id, user, require_admin=require_write)
             return workflow
         raise BusinessError(
             code=ResponseCode.FORBIDDEN,

--- a/backend/app/core/celery.py
+++ b/backend/app/core/celery.py
@@ -79,6 +79,7 @@ celery_app.conf.task_routes = {
     "app.tasks.agent.*": {"queue": "default"},
     "app.tasks.memory.*": {"queue": "default"},
     "tasks.cleanup_expired_sandbox_sessions": {"queue": "sandbox"},
+    "tasks.sweep_lost_agent_runs": {"queue": "default"},
     "tasks.archive_old_audit_logs": {"queue": "default"},
     "tasks.check_api_key_expiration": {"queue": "default"},
     "tasks.check_password_expiration": {"queue": "default"},
@@ -118,6 +119,14 @@ celery_app.conf.beat_schedule = {
         "task": "tasks.cleanup_expired_sandbox_sessions",
         "schedule": crontab(minute="*/15"),
         "options": {"queue": "sandbox"},
+    },
+    # Detect AgentRuns whose worker died and mark them INTERRUPTED. The run
+    # lease is 60s, so sweeping every 2 minutes bounds how long a crash stays
+    # reported as in-flight. This is the only producer of INTERRUPTED.
+    "sweep-lost-agent-runs": {
+        "task": "tasks.sweep_lost_agent_runs",
+        "schedule": crontab(minute="*/2"),
+        "options": {"queue": "default"},
     },
 }
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from pydantic import ValidationInfo, field_validator
+from pydantic import Field, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -39,7 +39,10 @@ class Settings(BaseSettings):
     # remaining queries behind its own fan-out. Raising the pool size instead is
     # not an option: PostgreSQL max_connections is 100 and the default
     # deployment runs ~17 processes x pool, so the ceiling is approached.
-    DB_AGGREGATE_CONCURRENCY: int = 4
+    #
+    # gt=0 is load-bearing: a semaphore built with 0 permits deadlocks every
+    # aggregate request, and a negative one raises ValueError at import time.
+    DB_AGGREGATE_CONCURRENCY: int = Field(default=4, gt=0)
 
     # Redis
     REDIS_HOST: str = "localhost"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -32,6 +32,14 @@ class Settings(BaseSettings):
     POSTGRES_DB: str = "clouisle"
     POSTGRES_PORT: int = 5432
     DATABASE_URL: str = ""
+    # Upper bound on aggregation queries one request may hold open at once.
+    # Endpoints that fan several independent aggregates out with asyncio.gather
+    # must not be able to occupy every slot of the shared Tortoise pool (default
+    # maxsize 5) in a single request, which would queue that request's
+    # remaining queries behind its own fan-out. Raising the pool size instead is
+    # not an option: PostgreSQL max_connections is 100 and the default
+    # deployment runs ~17 processes x pool, so the ceiling is approached.
+    DB_AGGREGATE_CONCURRENCY: int = 4
 
     # Redis
     REDIS_HOST: str = "localhost"

--- a/backend/app/core/db_limits.py
+++ b/backend/app/core/db_limits.py
@@ -1,0 +1,34 @@
+"""Bounds how many aggregation queries a request may hold open at once.
+
+Several statistics endpoints fan independent aggregates out with
+``asyncio.gather``. Without a bound, one request can hold every slot of the
+shared Tortoise pool (default ``maxsize`` 5) while its own remaining queries
+queue behind it. Raising the pool is not an option: PostgreSQL
+``max_connections`` is 100 and the default deployment already runs roughly 17
+processes x pool.
+
+The limiter is a single process-wide semaphore, shared by every fan-out, so the
+configured number bounds the whole process rather than each endpoint
+separately. It is applied per query — acquiring once around a ``gather`` of N
+coroutines would let N queries run under a single permit and defeat the bound.
+"""
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any, TypeVar
+
+from app.core.config import settings
+
+T = TypeVar("T")
+
+_AGGREGATE_SEMAPHORE = asyncio.Semaphore(settings.DB_AGGREGATE_CONCURRENCY)
+
+
+async def run_bounded(coro: Coroutine[Any, Any, T]) -> T:
+    """Await ``coro`` holding one aggregation permit.
+
+    Wrap each coroutine handed to an ``asyncio.gather`` so concurrent
+    aggregates are limited rather than merely cooperative.
+    """
+    async with _AGGREGATE_SEMAPHORE:
+        return await coro

--- a/backend/app/services/admin_observability.py
+++ b/backend/app/services/admin_observability.py
@@ -15,7 +15,7 @@ from uuid import UUID
 from tortoise import Tortoise
 
 from app.core.celery import celery_app
-from app.core.config import settings
+from app.core.db_limits import run_bounded
 from app.core.redis import get_redis
 from app.core.timezone import now, to_utc
 from app.models.workflow import RunStatus
@@ -29,11 +29,6 @@ logger = logging.getLogger(__name__)
 
 CACHE_TTL_SECONDS = 30
 CACHE_PREFIX = "admin:observability:v1"
-
-# One semaphore per process, shared with the other statistics fan-outs. Capping
-# concurrent aggregates keeps a single request from occupying every slot of the
-# shared Tortoise pool while its own queries queue behind it.
-_AGGREGATE_SEMAPHORE = asyncio.Semaphore(settings.DB_AGGREGATE_CONCURRENCY)
 HEALTH_SNAPSHOT_KEY = f"{CACHE_PREFIX}:system:health:snapshots"
 VALID_TIME_RANGES = {"7d", "30d", "90d", "all"}
 VALID_GRANULARITIES = {"hour", "day"}
@@ -361,14 +356,13 @@ async def _tracked_model_token_rows(time_range: str) -> list[dict[str, Any]]:
 
 async def get_tokens(time_range: str) -> dict[str, Any]:
     start_time, end_time = normalize_time_range(time_range)
-    # Bounded fan-out: three concurrent aggregates must not occupy the whole
-    # shared pool, which is sized for the default deployment's connections.
-    async with _AGGREGATE_SEMAPHORE:
-        agent_rows, workflow_tokens, tracked_rows = await asyncio.gather(
-            _agent_model_token_rows(start_time, end_time),
-            _workflow_token_total(start_time, end_time),
-            _tracked_model_token_rows(time_range),
-        )
+    # Per-query permits: one permit around the whole gather would let three
+    # queries run under a single slot and exceed the configured bound.
+    agent_rows, workflow_tokens, tracked_rows = await asyncio.gather(
+        run_bounded(_agent_model_token_rows(start_time, end_time)),
+        run_bounded(_workflow_token_total(start_time, end_time)),
+        run_bounded(_tracked_model_token_rows(time_range)),
+    )
 
     by_model: dict[str, int] = {}
     for row in agent_rows:

--- a/backend/app/services/admin_observability.py
+++ b/backend/app/services/admin_observability.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from tortoise import Tortoise
 
 from app.core.celery import celery_app
+from app.core.config import settings
 from app.core.redis import get_redis
 from app.core.timezone import now, to_utc
 from app.models.workflow import RunStatus
@@ -28,6 +29,11 @@ logger = logging.getLogger(__name__)
 
 CACHE_TTL_SECONDS = 30
 CACHE_PREFIX = "admin:observability:v1"
+
+# One semaphore per process, shared with the other statistics fan-outs. Capping
+# concurrent aggregates keeps a single request from occupying every slot of the
+# shared Tortoise pool while its own queries queue behind it.
+_AGGREGATE_SEMAPHORE = asyncio.Semaphore(settings.DB_AGGREGATE_CONCURRENCY)
 HEALTH_SNAPSHOT_KEY = f"{CACHE_PREFIX}:system:health:snapshots"
 VALID_TIME_RANGES = {"7d", "30d", "90d", "all"}
 VALID_GRANULARITIES = {"hour", "day"}
@@ -355,11 +361,14 @@ async def _tracked_model_token_rows(time_range: str) -> list[dict[str, Any]]:
 
 async def get_tokens(time_range: str) -> dict[str, Any]:
     start_time, end_time = normalize_time_range(time_range)
-    agent_rows, workflow_tokens, tracked_rows = await asyncio.gather(
-        _agent_model_token_rows(start_time, end_time),
-        _workflow_token_total(start_time, end_time),
-        _tracked_model_token_rows(time_range),
-    )
+    # Bounded fan-out: three concurrent aggregates must not occupy the whole
+    # shared pool, which is sized for the default deployment's connections.
+    async with _AGGREGATE_SEMAPHORE:
+        agent_rows, workflow_tokens, tracked_rows = await asyncio.gather(
+            _agent_model_token_rows(start_time, end_time),
+            _workflow_token_total(start_time, end_time),
+            _tracked_model_token_rows(time_range),
+        )
 
     by_model: dict[str, int] = {}
     for row in agent_rows:

--- a/backend/app/services/stats_sql.py
+++ b/backend/app/services/stats_sql.py
@@ -40,11 +40,22 @@ _GRANULARITIES = frozenset({"hour", "day"})
 # Derived from the model enums so a newly added status cannot be silently
 # classified as success or dropped from the denominator.
 AGENT_RUN_STATUS_VALUES = frozenset(status.value for status in AgentRunStatus)
+# A terminal run never transitions again. This set must match the persistence
+# layer's own notion of "finished": ``agent_run_store._build_transition_updates``
+# stamps ``finished_at`` for exactly these four, and ``enqueue_input`` rejects
+# them as already-finished. ``INTERRUPTED`` is the worker-loss outcome written by
+# ``mark_expired_runs_interrupted``; treating it as in-flight would report a
+# crashed run as still running and hide it from the success rate.
 TERMINAL_AGENT_RUN_STATUSES = frozenset(
     status.value
     for status in AgentRunStatus
     if status
-    in {AgentRunStatus.COMPLETED, AgentRunStatus.FAILED, AgentRunStatus.STOPPED}
+    in {
+        AgentRunStatus.COMPLETED,
+        AgentRunStatus.FAILED,
+        AgentRunStatus.STOPPED,
+        AgentRunStatus.INTERRUPTED,
+    }
 )
 IN_FLIGHT_AGENT_RUN_STATUSES = AGENT_RUN_STATUS_VALUES - TERMINAL_AGENT_RUN_STATUSES
 AGENT_RUN_INPUT_KIND_VALUES = frozenset(kind.value for kind in AgentRunInputKind)
@@ -422,6 +433,11 @@ async def agent_run_health(
       finalised (NULL), so counting round status would silently omit every
       crash from the denominator.
 
+    A crashed run is not silently omitted either: worker loss writes
+    ``INTERRUPTED``, which is terminal (see ``TERMINAL_AGENT_RUN_STATUSES``)
+    and is reported as its own ``interrupted`` count so the outcome is visible
+    rather than disguised as an in-flight run.
+
     Terminal states are compared against the ``AgentRunStatus`` enum so a new
     status cannot be silently classified as success.
 
@@ -449,12 +465,17 @@ async def agent_run_health(
     )
 
     counts: dict[str, int] = {}
+    unknown: list[str] = []
     for row in rows:
         status = row["status"]
         if status not in AGENT_RUN_STATUS_VALUES:
-            # An unrecognised status is surfaced instead of being folded into
-            # a bucket, so enum drift cannot masquerade as a clean run.
-            raise ValueError(f"Unknown agent run status in database: {status!r}")
+            # Enum drift (a status written by an older or newer release) must
+            # not be folded into a bucket and must not turn a read-only
+            # statistics endpoint into a 500. It is counted separately so it is
+            # visible instead of misattributed: the run is real, its outcome is
+            # simply not recognised by this build.
+            unknown.append(str(status))
+            continue
         counts[status] = int(row["count"])
 
     terminal = sum(counts.get(status, 0) for status in TERMINAL_AGENT_RUN_STATUSES)
@@ -463,6 +484,10 @@ async def agent_run_health(
         "completed": completed,
         "failed": counts.get("failed", 0),
         "stopped": counts.get("stopped", 0),
+        "interrupted": counts.get("interrupted", 0),
+        "unrecognised": sum(
+            int(row["count"]) for row in rows if str(row["status"]) in unknown
+        ),
         "in_flight": sum(
             counts.get(status, 0) for status in IN_FLIGHT_AGENT_RUN_STATUSES
         ),

--- a/backend/app/tasks/agent.py
+++ b/backend/app/tasks/agent.py
@@ -89,3 +89,34 @@ def run_agent_task(self, payload: dict) -> dict:
             return {"status": AgentRunStatus.FAILED.value, "error": error_text}
 
         return _run_async(_mark_failed())
+
+
+@shared_task(name="tasks.sweep_lost_agent_runs", ignore_result=False)
+def sweep_lost_agent_runs_task(max_age_seconds: int = 120) -> dict:
+    """Mark runs whose worker died as INTERRUPTED.
+
+    A run whose process is killed mid-flight never reaches a terminal state:
+    its row stays ``running``/``stopping`` and its Redis lease expires. This
+    sweep is what actually writes ``AgentRunStatus.INTERRUPTED`` — without it
+    that status exists in the enum but is never produced, and a crashed run
+    stays reported as in-flight forever.
+
+    Safe to run on a schedule: ``mark_expired_runs_interrupted`` re-checks the
+    lease per run and never replays side-effecting work.
+    """
+
+    async def _sweep() -> dict:
+        from app.services.agent_run_store import mark_expired_runs_interrupted
+
+        try:
+            marked = await mark_expired_runs_interrupted(
+                max_age_seconds=max_age_seconds
+            )
+        except Exception:
+            logger.exception("Agent run worker-loss sweep failed")
+            raise
+        if marked:
+            logger.warning("Marked %s lost AgentRun(s) as interrupted", marked)
+        return {"marked": marked}
+
+    return _run_async(_sweep())

--- a/backend/tests/api/test_agent_stats_access_guards.py
+++ b/backend/tests/api/test_agent_stats_access_guards.py
@@ -1,12 +1,11 @@
 """Access control for the /agents/{agent_id}/stats endpoints (YUN-153).
 
-Agent statistics, activity trends, tool usage and recent conversation metadata
-must not be readable across team or private-agent boundaries.
+Agent statistics, activity trends and tool usage must not be readable across
+team or private-agent boundaries.
 """
 
-from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -19,7 +18,6 @@ STATS_ENDPOINTS = [
     agent_stats.get_agent_stats,
     agent_stats.get_agent_trends,
     agent_stats.get_agent_tool_usage,
-    agent_stats.get_recent_conversations,
 ]
 
 
@@ -42,26 +40,6 @@ class _AgentModel:
         return _AgentQuery(cls.agent)
 
 
-class _ConversationQuery:
-    def __init__(self, conversations):
-        self.conversations = conversations
-
-    def order_by(self, *_fields):
-        return self
-
-    def limit(self, _value):
-        return self
-
-    def prefetch_related(self, *_relations):
-        return self
-
-    def __await__(self):
-        async def resolve():
-            return self.conversations
-
-        return resolve().__await__()
-
-
 def _agent(*, visibility: AgentVisibility, team_id, creator_id):
     return SimpleNamespace(
         id=uuid4(),
@@ -80,7 +58,6 @@ async def test_stats_endpoints_deny_foreign_private_agent_before_reading_data(
         visibility=AgentVisibility.PRIVATE, team_id=uuid4(), creator_id=uuid4()
     )
     _AgentModel.agent = agent
-    conversation_filter = MagicMock()
     aggregates = {
         name: MagicMock()
         for name in (
@@ -94,7 +71,6 @@ async def test_stats_endpoints_deny_foreign_private_agent_before_reading_data(
         )
     }
     monkeypatch.setattr(agents, "Agent", _AgentModel)
-    monkeypatch.setattr(agent_stats.Conversation, "filter", conversation_filter)
     display_names = MagicMock()
     monkeypatch.setattr(agent_stats, "get_tool_display_names", display_names)
     for name, stub in aggregates.items():
@@ -110,39 +86,6 @@ async def test_stats_endpoints_deny_foreign_private_agent_before_reading_data(
         403,
     )
     # Authorization must short-circuit before any statistics data is touched.
-    conversation_filter.assert_not_called()
     display_names.assert_not_called()
     for stub in aggregates.values():
         stub.assert_not_called()
-
-
-@pytest.mark.anyio
-async def test_recent_conversations_allows_non_owner_team_member(monkeypatch):
-    team_id = uuid4()
-    agent = _agent(visibility=AgentVisibility.TEAM, team_id=team_id, creator_id=uuid4())
-    user = SimpleNamespace(id=uuid4(), is_superuser=False)
-    timestamp = datetime(2026, 9, 12, tzinfo=UTC)
-    member = SimpleNamespace(
-        id=uuid4(),
-        title="Shared",
-        user=SimpleNamespace(id=uuid4(), username="member"),
-        message_count=2,
-        token_usage=5,
-        created_at=timestamp,
-        updated_at=timestamp,
-    )
-    _AgentModel.agent = agent
-    check_team = AsyncMock()
-    monkeypatch.setattr(agents, "Agent", _AgentModel)
-    monkeypatch.setattr(agents, "check_team_access", check_team)
-    monkeypatch.setattr(
-        agent_stats.Conversation,
-        "filter",
-        lambda **_kwargs: _ConversationQuery([member]),
-    )
-
-    response = await agent_stats.get_recent_conversations(agent.id, current_user=user)
-
-    check_team.assert_awaited_once_with(team_id, user)
-    assert response["data"][0]["title"] == "Shared"
-    assert response["data"][0]["user"]["username"] == "member"

--- a/backend/tests/api/test_agent_stats_issue255.py
+++ b/backend/tests/api/test_agent_stats_issue255.py
@@ -3,50 +3,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
+import asyncio
 import pytest
 
 from app.api.v1.endpoints import agent_stats
 from app.schemas.response import BusinessError, ResponseCode
-
-
-class Query:
-    def __init__(self, result=None, *, counts=None, values=None, value_batches=None):
-        self.result = result
-        self.counts = iter(counts or [0])
-        self.value = values if values is not None else []
-        self.value_batches = iter(value_batches) if value_batches is not None else None
-
-    def filter(self, **kwargs):
-        return self
-
-    def order_by(self, *args):
-        return self
-
-    def limit(self, value):
-        return self
-
-    def prefetch_related(self, *args):
-        return self
-
-    def annotate(self, **kwargs):
-        return self
-
-    async def count(self):
-        return next(self.counts)
-
-    async def values(self, *args):
-        return (
-            next(self.value_batches) if self.value_batches is not None else self.value
-        )
-
-    async def values_list(self, *args, **kwargs):
-        return self.value
-
-    def __await__(self):
-        async def resolve():
-            return self.result
-
-        return resolve().__await__()
 
 
 @pytest.mark.anyio
@@ -56,7 +17,6 @@ class Query:
         agent_stats.get_agent_stats,
         agent_stats.get_agent_trends,
         agent_stats.get_agent_tool_usage,
-        agent_stats.get_recent_conversations,
     ],
 )
 async def test_agent_stats_endpoints_reject_missing_agent(monkeypatch, function):
@@ -209,6 +169,116 @@ async def test_agent_trends_emit_one_point_per_bucket(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("period", "first_point"),
+    [
+        # 12:37 must not be used as the window start: the first hourly point is
+        # 13:00 the previous day, so the window must start there or the leading
+        # partial bucket is fetched and then discarded.
+        ("24h", datetime(2026, 7, 20, 13, 0, tzinfo=UTC)),
+        ("7d", datetime(2026, 7, 15, 0, 0, tzinfo=UTC)),
+        ("30d", datetime(2026, 6, 22, 0, 0, tzinfo=UTC)),
+    ],
+)
+async def test_agent_trends_window_starts_at_the_first_rendered_bucket(
+    monkeypatch, period, first_point
+):
+    fixed_now = datetime(2026, 7, 21, 12, 37, tzinfo=UTC)
+    monkeypatch.setattr(agent_stats, "now", lambda: fixed_now)
+    monkeypatch.setattr(agent_stats, "check_agent_access", AsyncMock())
+    buckets = AsyncMock(return_value={})
+    monkeypatch.setattr(agent_stats.stats_sql, "agent_trend_buckets", buckets)
+
+    result = await agent_stats.get_agent_trends(
+        uuid4(), period=period, current_user=SimpleNamespace()
+    )
+
+    # args[1] is the window start handed to the SQL; it must equal the first
+    # point's timestamp, or rows bucket to a key the chart never renders.
+    window_start = buckets.await_args.args[1]
+    assert window_start == first_point
+    assert result["data"]["data"][0]["timestamp"] == first_point.isoformat()
+
+
+@pytest.mark.anyio
+async def test_agent_stats_fan_out_is_bounded_by_the_aggregate_budget(monkeypatch):
+    """One request must not hold the whole connection pool open.
+
+    The five aggregates used to be issued as five simultaneous pool checkouts
+    against a pool of five. They are now gated so at most
+    ``DB_AGGREGATE_CONCURRENCY`` are in flight at once.
+    """
+    monkeypatch.setattr(agent_stats, "check_agent_access", AsyncMock())
+    monkeypatch.setattr(agent_stats.settings, "DB_AGGREGATE_CONCURRENCY", 2)
+    monkeypatch.setattr(agent_stats, "_AGGREGATE_SEMAPHORE", asyncio.Semaphore(2))
+
+    in_flight = 0
+    peak = 0
+
+    def _stub(result):
+        async def _run(*_args, **_kwargs):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0)
+            in_flight -= 1
+            return result
+
+        return _run
+
+    monkeypatch.setattr(
+        agent_stats.stats_sql,
+        "agent_conversation_overview",
+        _stub({"total_conversations": 0, "active_users": 0}),
+    )
+    monkeypatch.setattr(
+        agent_stats.stats_sql,
+        "agent_message_overview",
+        _stub(
+            {
+                "user_messages": 0,
+                "assistant_messages": 0,
+                "tool_messages": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "tool_call_count": 0,
+                "avg_duration": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        agent_stats.stats_sql,
+        "agent_run_health",
+        _stub(
+            {
+                "completed": 0,
+                "failed": 0,
+                "stopped": 0,
+                "interrupted": 0,
+                "unrecognised": 0,
+                "in_flight": 0,
+                "total": 0,
+                "success_rate": 0.0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        agent_stats.stats_sql,
+        "agent_latency_percentiles",
+        _stub({"p50": 0.0, "p95": 0.0, "avg": 0.0, "samples": 0}),
+    )
+    monkeypatch.setattr(
+        agent_stats.stats_sql,
+        "agent_intervention_counts",
+        _stub({"steer": 0, "stop": 0, "follow_up": 0, "total": 0}),
+    )
+
+    await agent_stats.get_agent_stats(uuid4(), period="all", current_user=None)
+
+    assert peak == 2, "fan-out must respect DB_AGGREGATE_CONCURRENCY"
+
+
+@pytest.mark.anyio
 async def test_tool_usage_preserves_database_ordering(monkeypatch):
     monkeypatch.setattr(
         agent_stats, "check_agent_access", AsyncMock(return_value=SimpleNamespace())
@@ -238,39 +308,3 @@ async def test_tool_usage_preserves_database_ordering(monkeypatch):
         {"name": "fetch", "display_name": "Fetch", "count": 1},
     ]
     assert result["data"]["total_calls"] == 3
-
-
-@pytest.mark.anyio
-async def test_recent_conversations_serializes_optional_user(monkeypatch):
-    timestamp = datetime(2026, 7, 21, tzinfo=UTC)
-    conversations = [
-        SimpleNamespace(
-            id=uuid4(),
-            title="With user",
-            user=SimpleNamespace(id=uuid4(), username="alice"),
-            message_count=2,
-            token_usage=3,
-            created_at=timestamp,
-            updated_at=timestamp,
-        ),
-        SimpleNamespace(
-            id=uuid4(),
-            title="Anonymous",
-            user=None,
-            message_count=0,
-            token_usage=0,
-            created_at=timestamp,
-            updated_at=timestamp,
-        ),
-    ]
-    monkeypatch.setattr(agent_stats, "check_agent_access", AsyncMock())
-    monkeypatch.setattr(
-        agent_stats.Conversation, "filter", lambda **kwargs: Query(conversations)
-    )
-
-    result = await agent_stats.get_recent_conversations(
-        uuid4(), limit=2, current_user=SimpleNamespace()
-    )
-
-    assert result["data"][0]["user"]["username"] == "alice"
-    assert result["data"][1]["user"] is None

--- a/backend/tests/api/test_agent_stats_issue255.py
+++ b/backend/tests/api/test_agent_stats_issue255.py
@@ -208,9 +208,11 @@ async def test_agent_stats_fan_out_is_bounded_by_the_aggregate_budget(monkeypatc
     against a pool of five. They are now gated so at most
     ``DB_AGGREGATE_CONCURRENCY`` are in flight at once.
     """
+    from app.core import db_limits
+
     monkeypatch.setattr(agent_stats, "check_agent_access", AsyncMock())
-    monkeypatch.setattr(agent_stats.settings, "DB_AGGREGATE_CONCURRENCY", 2)
-    monkeypatch.setattr(agent_stats, "_AGGREGATE_SEMAPHORE", asyncio.Semaphore(2))
+    # The limiter is shared process-wide, so patch it where it is defined.
+    monkeypatch.setattr(db_limits, "_AGGREGATE_SEMAPHORE", asyncio.Semaphore(2))
 
     in_flight = 0
     peak = 0

--- a/backend/tests/api/test_agent_stats_residual_companion_issue255.py
+++ b/backend/tests/api/test_agent_stats_residual_companion_issue255.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -6,42 +6,20 @@ from uuid import uuid4
 import pytest
 
 from app.api.v1.endpoints import agent_stats
-from app.models.agent import MessageRole
-
-
-class StatsQuery:
-    def __init__(self, *, values=None):
-        self.values_result = values or {}
-        self.filters = []
-
-    def filter(self, **kwargs):
-        self.filters.append(kwargs)
-        return self
-
-    def annotate(self, **_kwargs):
-        return self
-
-    async def count(self):
-        role = next(
-            (item["role"] for item in reversed(self.filters) if "role" in item), None
-        )
-        return {
-            None: 2,
-            MessageRole.USER: 1,
-            MessageRole.ASSISTANT: 2,
-            MessageRole.TOOL: 1,
-        }[role]
-
-    async def values(self, *fields):
-        return self.values_result.get(fields, [])
-
-    async def values_list(self, *_fields, **_kwargs):
-        return [uuid4(), uuid4(), uuid4()]
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("period", ["24h", "7d", "30d", "all"])
-async def test_agent_stats_bounds_every_period_except_all(monkeypatch, period):
+@pytest.mark.parametrize(
+    ("period", "delta"),
+    [
+        ("24h", timedelta(hours=24)),
+        ("7d", timedelta(days=7)),
+        ("30d", timedelta(days=30)),
+        ("all", None),
+    ],
+)
+async def test_agent_stats_bounds_every_period_except_all(monkeypatch, period, delta):
+    fixed_now = datetime(2026, 7, 22, 12, tzinfo=UTC)
     conversations = AsyncMock(
         return_value={"total_conversations": 1, "active_users": 1}
     )
@@ -57,6 +35,7 @@ async def test_agent_stats_bounds_every_period_except_all(monkeypatch, period):
         }
     )
     monkeypatch.setattr(agent_stats, "check_agent_access", AsyncMock())
+    monkeypatch.setattr(agent_stats, "now", lambda: fixed_now)
     monkeypatch.setattr(
         agent_stats.stats_sql, "agent_conversation_overview", conversations
     )
@@ -90,12 +69,12 @@ async def test_agent_stats_bounds_every_period_except_all(monkeypatch, period):
 
     assert result["data"]["tokens"]["total_tokens"] == 5
     assert result["data"]["tools"]["tool_call_count"] == 3
-    # "all" must scan without a lower bound; every other period must pass one,
-    # and both aggregates must agree on the window or the numbers disagree.
-    expected_bound = None if period == "all" else "bounded"
+    # "all" must scan without a lower bound; every other period must pass the
+    # exact window it advertises, and both aggregates must agree on it or the
+    # numbers disagree.
+    expected = None if delta is None else fixed_now - delta
     for call in (conversations, messages):
-        start_time = call.await_args.args[1]
-        assert (None if start_time is None else "bounded") == expected_bound
+        assert call.await_args.args[1] == expected
     assert conversations.await_args.args[1] == messages.await_args.args[1]
 
 
@@ -123,7 +102,9 @@ async def test_agent_trends_day_ranges_fill_every_point(
 
 @pytest.mark.anyio
 async def test_tool_usage_bounds_seven_day_window(monkeypatch):
+    fixed_now = datetime(2026, 7, 22, 12, tzinfo=UTC)
     usage = AsyncMock(return_value=[{"name": "search", "count": 2}])
+    monkeypatch.setattr(agent_stats, "now", lambda: fixed_now)
     monkeypatch.setattr(
         agent_stats, "check_agent_access", AsyncMock(return_value=SimpleNamespace())
     )
@@ -141,4 +122,5 @@ async def test_tool_usage_bounds_seven_day_window(monkeypatch):
     assert result["data"]["tools"] == [
         {"name": "search", "display_name": "Search", "count": 2}
     ]
-    assert usage.await_args.args[1] is not None
+    # "7d" must mean exactly seven days, not merely "some bound".
+    assert usage.await_args.args[1] == fixed_now - timedelta(days=7)

--- a/backend/tests/api/test_agent_stats_tool_usage_issue255.py
+++ b/backend/tests/api/test_agent_stats_tool_usage_issue255.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, UTC
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -10,19 +11,6 @@ from fastapi.testclient import TestClient
 from app.api import deps
 from app.api.v1.endpoints import agent_stats
 from app.schemas.response import BusinessError, ResponseCode, error
-
-
-class Query:
-    def __init__(self, *, values=None):
-        self.values_result = values or []
-        self.filters = []
-
-    def filter(self, **kwargs):
-        self.filters.append(kwargs)
-        return self
-
-    async def values(self, *fields):
-        return self.values_result
 
 
 @pytest.fixture
@@ -89,12 +77,14 @@ def test_tool_usage_returns_not_found_for_missing_agent(client, monkeypatch):
 
 def test_tool_usage_aggregates_supported_shapes_for_24_hours(client, monkeypatch):
     agent_id = uuid4()
+    fixed_now = datetime(2026, 7, 22, 12, tzinfo=UTC)
     usage = AsyncMock(
         return_value=[
             {"name": "search", "count": 2},
             {"name": "fetch", "count": 1},
         ]
     )
+    monkeypatch.setattr(agent_stats, "now", lambda: fixed_now)
     monkeypatch.setattr(
         agent_stats, "check_agent_access", AsyncMock(return_value=SimpleNamespace())
     )
@@ -118,7 +108,7 @@ def test_tool_usage_aggregates_supported_shapes_for_24_hours(client, monkeypatch
         ],
         "total_calls": 3,
     }
-    assert usage.await_args.args[1] is not None
+    assert usage.await_args.args[1] == fixed_now - timedelta(hours=24)
     # MCP enumeration must stay off: it is an untimed network call.
     assert agent_stats.get_tool_display_names.await_args.kwargs == {
         "enumerate_mcp_tools": False

--- a/backend/tests/api/test_scoped_rbac_access.py
+++ b/backend/tests/api/test_scoped_rbac_access.py
@@ -266,17 +266,48 @@ async def test_unowned_private_workflow_requires_team_membership(monkeypatch):
     monkeypatch.setattr("app.api.workflow_access.check_team_access", check_team)
 
     assert await check_workflow_access(workflow.id, user) is workflow
-    check_team.assert_awaited_once_with(team.id, user)
+    check_team.assert_awaited_once_with(team.id, user, require_admin=False)
 
 
 @pytest.mark.anyio
-async def test_private_workflow_write_requires_team_admin(monkeypatch):
+async def test_private_workflow_write_rejects_non_owner_team_admin(monkeypatch):
+    """PRIVATE means creator-only, and that must hold for writes too.
+
+    A team admin used to be allowed to write another member's private workflow
+    via its id, even though the list and stats scope hides those rows from
+    them — an id-guessing IDOR. The model's own contract is "Only creator can
+    access", matching check_agent_access.
+    """
     user = SimpleNamespace(id=uuid4(), is_superuser=False)
     team = SimpleNamespace(id=uuid4())
     workflow = SimpleNamespace(
         id=uuid4(),
         visibility=WorkflowVisibility.PRIVATE,
         created_by=SimpleNamespace(id=uuid4()),
+        team=team,
+    )
+    _WorkflowModel.workflow = workflow
+    check_team = AsyncMock()
+    monkeypatch.setattr("app.api.workflow_access.Workflow", _WorkflowModel)
+    monkeypatch.setattr("app.api.workflow_access.check_team_access", check_team)
+
+    with pytest.raises(BusinessError) as error:
+        await check_workflow_access(workflow.id, user, require_write=True)
+
+    assert error.value.msg_key == "workflow_access_denied"
+    # The team check must not even be reached: admin is not creator.
+    check_team.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_unowned_private_workflow_write_requires_team_admin(monkeypatch):
+    """A creator-less legacy row has no owner to protect, so team scope governs."""
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    team = SimpleNamespace(id=uuid4())
+    workflow = SimpleNamespace(
+        id=uuid4(),
+        visibility=WorkflowVisibility.PRIVATE,
+        created_by=None,
         team=team,
     )
     _WorkflowModel.workflow = workflow

--- a/backend/tests/api/test_workflow_endpoint_residuals_issue255.py
+++ b/backend/tests/api/test_workflow_endpoint_residuals_issue255.py
@@ -4,11 +4,27 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+from tortoise.expressions import Q
 
 from app.api import workflow_access
 from app.api.v1.endpoints import workflows
-from app.models.workflow import RunStatus, TriggerType, WorkflowStatus
+from app.models.workflow import (
+    RunStatus,
+    TriggerType,
+    WorkflowStatus,
+    WorkflowVisibility,
+)
 from app.schemas.response import BusinessError
+
+
+def _flatten(node) -> list[dict]:
+    """Collect the leaf filter kwargs of a (possibly nested) Q tree."""
+    if not node.children:
+        return [dict(node.filters)]
+    leaves: list[dict] = []
+    for child in node.children:
+        leaves.extend(_flatten(child))
+    return leaves
 
 
 class _Query:
@@ -59,8 +75,11 @@ class _Query:
 
 
 class _MembershipQuery:
+    def __init__(self, team_ids=None):
+        self.team_ids = list(team_ids) if team_ids is not None else [uuid4()]
+
     async def values_list(self, *args, **kwargs):
-        return [uuid4()]
+        return self.team_ids
 
 
 @pytest.mark.anyio
@@ -107,6 +126,7 @@ async def test_workflow_run_stats_team_filter_calculates_completed_average(monke
     workflow = SimpleNamespace(id=workflow_id, name="Flow", icon=None)
     workflow_query = _Query([workflow])
     access = AsyncMock()
+    membership_team_id = uuid4()
 
     monkeypatch.setattr(workflows, "check_team_access", access)
     monkeypatch.setattr(workflows.Workflow, "all", lambda: workflow_query)
@@ -123,7 +143,9 @@ async def test_workflow_run_stats_team_filter_calculates_completed_average(monke
         ),
     )
     monkeypatch.setattr(
-        workflow_access.TeamMember, "filter", lambda **kwargs: _MembershipQuery()
+        workflow_access.TeamMember,
+        "filter",
+        lambda **kwargs: _MembershipQuery([membership_team_id]),
     )
 
     response = await workflows.get_workflow_run_stats(
@@ -133,8 +155,21 @@ async def test_workflow_run_stats_team_filter_calculates_completed_average(monke
     access.assert_awaited_once()
     assert workflow_query.filters[0][1] == {"team_id": access.call_args.args[0]}
     # The visibility scope is applied after the team filter so private
-    # workflows of other members stay out of the aggregate (YUN-153).
-    assert workflow_query.filters[1][0] != ()
+    # workflows of other members stay out of the aggregate (YUN-153). Assert
+    # the scope's actual branches: any Q would satisfy a non-empty check.
+    scope_args, scope_kwargs = workflow_query.filters[1]
+    assert scope_kwargs == {}
+    scope = scope_args[0]
+    assert isinstance(scope, Q)
+    leaves = _flatten(scope)
+    assert {
+        "team_id__in": [membership_team_id],
+        "visibility__in": [WorkflowVisibility.TEAM, WorkflowVisibility.PUBLIC],
+    } in leaves
+    assert any(
+        leaf.get("visibility") == WorkflowVisibility.PRIVATE and "created_by_id" in leaf
+        for leaf in leaves
+    ), "the caller's own private workflows must stay readable"
     assert response["data"]["avg_duration_ms"] == 1500
 
 

--- a/backend/tests/api/test_workflows_residual_matrix_issue255.py
+++ b/backend/tests/api/test_workflows_residual_matrix_issue255.py
@@ -4,11 +4,22 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+from tortoise.expressions import Q
 
 from app.api import workflow_access
 from app.api.v1.endpoints import workflows
-from app.models.workflow import RunStatus, TriggerType
+from app.models.workflow import RunStatus, TriggerType, WorkflowVisibility
 from app.schemas.response import BusinessError, ResponseCode
+
+
+def _flatten(node) -> list[dict]:
+    """Collect the leaf filter kwargs of a (possibly nested) Q tree."""
+    if not node.children:
+        return [dict(node.filters)]
+    leaves: list[dict] = []
+    for child in node.children:
+        leaves.extend(_flatten(child))
+    return leaves
 
 
 class Query:
@@ -22,7 +33,7 @@ class Query:
         return self
 
     def filter(self, *args, **kwargs):
-        self.filters.append(kwargs)
+        self.filters.append((args, kwargs))
         return self
 
     def select_related(self, *_args):
@@ -117,16 +128,87 @@ async def test_global_run_list_applies_access_filters_and_serializes_relations(
     )
 
     access.assert_awaited_once_with(team_id, user)
-    assert {"team_id__in": [team_id]} in workflow_query.filters
-    assert {"workflow_id__in": [workflow_id]} in run_query.filters
-    assert {"status__in": [RunStatus.FAILED]} in run_query.filters
-    assert {"trigger_type__in": [TriggerType.WEBHOOK]} in run_query.filters
-    assert {"triggered_by_id__in": [user_id]} in run_query.filters
-    assert {"is_debug": False} in run_query.filters
+    assert ((), {"team_id__in": [team_id]}) in workflow_query.filters
+    assert ((), {"workflow_id__in": [workflow_id]}) in run_query.filters
+    assert ((), {"status__in": [RunStatus.FAILED]}) in run_query.filters
+    assert ((), {"trigger_type__in": [TriggerType.WEBHOOK]}) in run_query.filters
+    assert ((), {"triggered_by_id__in": [user_id]}) in run_query.filters
+    assert ((), {"is_debug": False}) in run_query.filters
     assert response["data"]["items"][0]["workflow_name"] == "Flow"
     assert response["data"]["items"][0]["triggered_by_name"] == "runner"
     assert response["data"]["items"][1]["workflow_name"] is None
     assert response["data"]["page"] == 2
+
+
+@pytest.mark.anyio
+async def test_global_run_list_applies_visibility_scope_to_workflow_queryset(
+    monkeypatch,
+):
+    """Removing the scope filter must fail here: /workflows/runs is the leak.
+
+    The endpoint passes the scope positionally, so a stub that recorded only
+    kwargs could not see it. This asserts the visibility ``Q`` actually reaches
+    the workflow queryset for a non-superuser.
+    """
+    user_id, team_id = uuid4(), uuid4()
+    user = SimpleNamespace(id=user_id, is_superuser=False)
+    workflow_query = Query([SimpleNamespace(id=uuid4())])
+    monkeypatch.setattr(workflows.Workflow, "all", Mock(return_value=workflow_query))
+    monkeypatch.setattr(
+        workflows.WorkflowRun, "filter", Mock(return_value=Query([], total=0))
+    )
+    monkeypatch.setattr(
+        workflow_access.TeamMember, "filter", Mock(return_value=Query([team_id]))
+    )
+
+    await workflows.list_all_workflow_runs(
+        team_id=None,
+        workflow_id=None,
+        status=None,
+        trigger_type=None,
+        user_id=None,
+        is_debug=None,
+        search=None,
+        page=1,
+        page_size=20,
+        current_user=user,
+    )
+
+    scopes = [args[0] for args, _kwargs in workflow_query.filters if args]
+    assert len(scopes) == 1, "the workflow queryset must be visibility-scoped once"
+    assert isinstance(scopes[0], Q)
+    leaves = _flatten(scopes[0])
+    # Team/public workflows only inside the caller's teams; own private
+    # workflows remain readable. A foreign member's private row matches none.
+    assert {
+        "team_id__in": [team_id],
+        "visibility__in": [WorkflowVisibility.TEAM, WorkflowVisibility.PUBLIC],
+    } in leaves
+    assert {
+        "created_by_id": user_id,
+        "visibility": WorkflowVisibility.PRIVATE,
+    } in leaves
+
+
+@pytest.mark.anyio
+async def test_global_run_stats_applies_visibility_scope_to_workflow_queryset(
+    monkeypatch,
+):
+    """``/workflows/runs/stats`` must scope its workflow set the same way."""
+    user_id, team_id = uuid4(), uuid4()
+    workflow_query = Query([])
+    monkeypatch.setattr(workflows.Workflow, "all", Mock(return_value=workflow_query))
+    monkeypatch.setattr(
+        workflow_access.TeamMember, "filter", Mock(return_value=Query([team_id]))
+    )
+
+    await workflows.get_workflow_run_stats(
+        team_id=None, current_user=SimpleNamespace(id=user_id, is_superuser=False)
+    )
+
+    scopes = [args[0] for args, _kwargs in workflow_query.filters if args]
+    assert len(scopes) == 1
+    assert isinstance(scopes[0], Q)
 
 
 @pytest.mark.anyio

--- a/backend/tests/services/test_admin_observability_analytics_issue255.py
+++ b/backend/tests/services/test_admin_observability_analytics_issue255.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -188,6 +189,42 @@ async def test_throughput_merges_metrics_and_current_counters(monkeypatch, perio
     assert result["granularity"] == "hour"
     assert result["current"] == {"qps": 0.5, "tps": 0.5, "running_workflows": 4}
     assert result["buckets"][0]["total_requests"] == 5
+
+
+@pytest.mark.asyncio
+async def test_token_analytics_bounds_each_query_not_each_batch(monkeypatch, period):
+    """One permit per query, not one per batch.
+
+    A single permit around the gather would let three queries run under one
+    slot, so N concurrent callers could reach 3N queries and defeat the bound.
+    """
+    from app.core import db_limits
+
+    monkeypatch.setattr(db_limits, "_AGGREGATE_SEMAPHORE", asyncio.Semaphore(2))
+
+    in_flight = 0
+    peak = 0
+
+    def _stub(result):
+        async def _run(*_args, **_kwargs):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0)
+            in_flight -= 1
+            return result
+
+        return _run
+
+    monkeypatch.setattr(service, "_agent_model_token_rows", _stub([]))
+    monkeypatch.setattr(service, "_workflow_token_total", _stub(0))
+    monkeypatch.setattr(service, "_tracked_model_token_rows", _stub([]))
+
+    # Two concurrent callers: three queries each, so an unbounded or
+    # batch-scoped limiter would observe all six at once.
+    await asyncio.gather(service.get_tokens("30d"), service.get_tokens("30d"))
+
+    assert peak <= 2, f"aggregate concurrency exceeded the budget: {peak}"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_agent_run_worker_lifecycle.py
+++ b/backend/tests/services/test_agent_run_worker_lifecycle.py
@@ -292,6 +292,34 @@ def test_agent_task_crash_does_not_overwrite_stopped_run(monkeypatch):
     transition.assert_not_awaited()
 
 
+def test_sweep_lost_agent_runs_task_reports_marked_count(monkeypatch):
+    """The scheduled sweep is the only producer of INTERRUPTED."""
+    from app.services import agent_run_store
+    from app.tasks import agent as agent_task
+
+    sweep = AsyncMock(return_value=3)
+    monkeypatch.setattr(agent_run_store, "mark_expired_runs_interrupted", sweep)
+
+    result = agent_task.sweep_lost_agent_runs_task.run(max_age_seconds=90)
+
+    assert result == {"marked": 3}
+    sweep.assert_awaited_once_with(max_age_seconds=90)
+
+
+def test_sweep_lost_agent_runs_task_reraises_so_beat_retries(monkeypatch):
+    from app.services import agent_run_store
+    from app.tasks import agent as agent_task
+
+    monkeypatch.setattr(
+        agent_run_store,
+        "mark_expired_runs_interrupted",
+        AsyncMock(side_effect=RuntimeError("redis unavailable")),
+    )
+
+    with pytest.raises(RuntimeError, match="redis unavailable"):
+        agent_task.sweep_lost_agent_runs_task.run()
+
+
 @pytest.mark.asyncio
 async def test_run_agent_round_missing_agent_or_conversation_marks_failed(
     monkeypatch, patched_store

--- a/backend/tests/services/test_chat_agent_tools_issue255.py
+++ b/backend/tests/services/test_chat_agent_tools_issue255.py
@@ -264,18 +264,31 @@ async def test_get_tool_display_names_skips_mcp_enumeration_when_disabled():
 
     ``McpClient.list_tools`` has no timeout, so a statistics request must not
     call it; the prefix lets the caller finish the label from the observed name.
+
+    The client METHOD is patched rather than the ``list_mcp_tools`` wrapper, so
+    this stays a real guarantee: a refactor that inlined
+    ``McpClient(config).list_tools()`` would still trip the tripwire.
     """
     agent = _agent([{"type": "mcp", "server_id": "server-id"}])
     mcp_tool = SimpleNamespace(
         name="github", display_name="GitHub", mcp_config={"url": "https://mcp.example"}
     )
-    list_mcp_tools = AsyncMock(side_effect=AssertionError("must not contact MCP"))
+    network = AsyncMock(
+        side_effect=AssertionError("must not contact MCP"),
+    )
 
     with (
         patch("app.models.tool.Tool.filter", return_value=_query_result(mcp_tool)),
-        patch("app.llm.tools.mcp_client.list_mcp_tools", new=list_mcp_tools),
+        patch(
+            "app.llm.tools.mcp_client.McpClient.list_tools",
+            new=network,
+        ),
+        patch(
+            "app.llm.tools.mcp_client.list_mcp_tools",
+            new=AsyncMock(side_effect=AssertionError("must not enumerate MCP")),
+        ),
     ):
         names = await get_tool_display_names(agent, "en", enumerate_mcp_tools=False)
 
     assert names == {"mcp_github_": "GitHub/"}
-    list_mcp_tools.assert_not_called()
+    network.assert_not_called()

--- a/backend/tests/services/test_stats_sql_contracts.py
+++ b/backend/tests/services/test_stats_sql_contracts.py
@@ -316,6 +316,9 @@ async def test_run_health_counts_only_terminal_states_in_the_rate(monkeypatch):
             {"status": "completed", "count": 9},
             {"status": "failed", "count": 1},
             {"status": "stopped", "count": 2},
+            # Worker loss is terminal: it must dilute the rate and be reported,
+            # not passed off as an in-flight run.
+            {"status": "interrupted", "count": 2},
             {"status": "running", "count": 4},
             {"status": "queued", "count": 3},
         ]
@@ -327,10 +330,36 @@ async def test_run_health_counts_only_terminal_states_in_the_rate(monkeypatch):
     assert result["completed"] == 9
     assert result["failed"] == 1
     assert result["stopped"] == 2
+    assert result["interrupted"] == 2
     assert result["in_flight"] == 7
-    # In-flight runs must not dilute the rate either way.
-    assert result["total"] == 12
-    assert result["success_rate"] == pytest.approx(9 / 12)
+    # In-flight runs must not dilute the rate; interrupted runs must.
+    assert result["total"] == 14
+    assert result["success_rate"] == pytest.approx(9 / 14)
+
+
+@pytest.mark.anyio
+async def test_run_health_reports_interrupted_runs_as_terminal_not_in_flight(
+    monkeypatch,
+):
+    """A crashed run must not masquerade as still running.
+
+    ``mark_expired_runs_interrupted`` is the only writer of this status, and
+    the persistence layer stamps ``finished_at`` for it.
+    """
+    conn = _Conn(
+        [
+            {"status": "interrupted", "count": 3},
+            {"status": "running", "count": 1},
+        ]
+    )
+    monkeypatch.setattr(stats_sql, "_connection", lambda: conn)
+
+    result = await stats_sql.agent_run_health(uuid4(), None)
+
+    assert result["interrupted"] == 3
+    assert result["in_flight"] == 1
+    assert result["total"] == 3
+    assert result["success_rate"] == 0.0
 
 
 @pytest.mark.anyio
@@ -345,13 +374,30 @@ async def test_run_health_without_terminal_runs_reports_zero_rate(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_run_health_rejects_unknown_status_instead_of_counting_it(monkeypatch):
-    """An unmapped status must not be silently folded into a category."""
-    conn = _Conn([{"status": "teleported", "count": 1}])
+async def test_run_health_surfaces_unknown_status_without_failing(monkeypatch):
+    """An unmapped status must be visible, not folded in — and not a 500.
+
+    A status written by another release is real data; raising here would turn a
+    read-only statistics request into a server error, while counting it as a
+    known outcome would misattribute it. It gets its own total instead.
+    """
+    conn = _Conn(
+        [
+            {"status": "completed", "count": 4},
+            {"status": "teleported", "count": 3},
+            {"status": "running", "count": 1},
+        ]
+    )
     monkeypatch.setattr(stats_sql, "_connection", lambda: conn)
 
-    with pytest.raises(ValueError, match="teleported"):
-        await stats_sql.agent_run_health(uuid4(), None)
+    result = await stats_sql.agent_run_health(uuid4(), None)
+
+    assert result["unrecognised"] == 3
+    # It must not inflate any known bucket...
+    assert result["completed"] == 4
+    assert result["in_flight"] == 1
+    assert result["total"] == 4
+    assert result["success_rate"] == pytest.approx(1.0)
 
 
 # --- First-token latency ----------------------------------------------------
@@ -416,10 +462,13 @@ async def test_intervention_counts_reject_unknown_kind(monkeypatch):
 
 def test_terminal_statuses_exclude_every_in_flight_state():
     """Guards the rate denominator if the enum gains a state."""
+    # Must stay in lockstep with agent_run_store's notion of "finished":
+    # _build_transition_updates stamps finished_at for exactly these four.
     assert stats_sql.TERMINAL_AGENT_RUN_STATUSES == {
         "completed",
         "failed",
         "stopped",
+        "interrupted",
     }
     assert stats_sql.TERMINAL_AGENT_RUN_STATUSES.isdisjoint(
         stats_sql.IN_FLIGHT_AGENT_RUN_STATUSES

--- a/backend/tests/test_celery_core_residual_issue255.py
+++ b/backend/tests/test_celery_core_residual_issue255.py
@@ -80,6 +80,12 @@ def test_configures_celery_with_and_without_redis_password(monkeypatch):
     assert app.conf.beat_schedule["cleanup-expired-sandbox-sessions"]["options"] == {
         "queue": "sandbox"
     }
+    # The worker-loss sweep is the only producer of INTERRUPTED; it must be
+    # scheduled and routed, or a crashed run stays reported as in-flight.
+    sweep = app.conf.beat_schedule["sweep-lost-agent-runs"]
+    assert sweep["task"] == "tasks.sweep_lost_agent_runs"
+    assert sweep["options"] == {"queue": "default"}
+    assert app.conf.task_routes["tasks.sweep_lost_agent_runs"] == {"queue": "default"}
 
     with_password, _ = _load_celery_module(monkeypatch, password="password")
     assert with_password.REDIS_URL == "redis://:password@redis.test:6380"

--- a/backend/tests/test_db_limits.py
+++ b/backend/tests/test_db_limits.py
@@ -1,0 +1,81 @@
+"""Contracts for the bounded aggregation fan-out.
+
+The limiter exists so one statistics request cannot hold every slot of the
+shared Tortoise pool while its own queries queue behind it. Two properties
+matter and neither is obvious from the call sites:
+
+- the configured budget must be usable, so a zero or negative value is
+  rejected at configuration time instead of deadlocking or raising later;
+- the budget applies per query, not per batch, or N concurrent callers would
+  reach ``N x batch_size`` queries and defeat it.
+"""
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from app.core import db_limits
+from app.core.config import Settings
+
+
+@pytest.mark.parametrize("value", [0, -1, -10])
+def test_aggregate_concurrency_rejects_non_positive_values(value):
+    """Zero permits would deadlock every aggregate; a negative count raises."""
+    with pytest.raises(ValidationError):
+        Settings(DB_AGGREGATE_CONCURRENCY=value)
+
+
+@pytest.mark.parametrize("value", [1, 4, 16])
+def test_aggregate_concurrency_accepts_positive_values(value):
+    assert Settings(DB_AGGREGATE_CONCURRENCY=value).DB_AGGREGATE_CONCURRENCY == value
+
+
+@pytest.mark.anyio
+async def test_run_bounded_returns_the_awaited_value(monkeypatch):
+    monkeypatch.setattr(db_limits, "_AGGREGATE_SEMAPHORE", asyncio.Semaphore(1))
+
+    async def _value():
+        return "ok"
+
+    assert await db_limits.run_bounded(_value()) == "ok"
+
+
+@pytest.mark.anyio
+async def test_run_bounded_limits_concurrency_per_query(monkeypatch):
+    """The permit is taken per coroutine, so a batch cannot exceed the budget."""
+    monkeypatch.setattr(db_limits, "_AGGREGATE_SEMAPHORE", asyncio.Semaphore(2))
+
+    in_flight = 0
+    peak = 0
+
+    async def _work():
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0)
+        in_flight -= 1
+
+    # Six independent queries, together with a one-permit-held batch scope this
+    # would have observed all six at once.
+    await asyncio.gather(*(db_limits.run_bounded(_work()) for _ in range(6)))
+
+    assert peak == 2
+
+
+@pytest.mark.anyio
+async def test_run_bounded_releases_the_permit_when_the_query_raises(monkeypatch):
+    """A failing aggregate must not leak its permit and stall the endpoint."""
+    monkeypatch.setattr(db_limits, "_AGGREGATE_SEMAPHORE", asyncio.Semaphore(1))
+
+    async def _boom():
+        raise RuntimeError("query failed")
+
+    with pytest.raises(RuntimeError, match="query failed"):
+        await db_limits.run_bounded(_boom())
+
+    # With the permit leaked this would hang rather than complete.
+    async def _ok():
+        return 1
+
+    assert await asyncio.wait_for(db_limits.run_bounded(_ok()), timeout=1) == 1

--- a/docs/guide/admin-guide/agents/agent-management.md
+++ b/docs/guide/admin-guide/agents/agent-management.md
@@ -185,7 +185,7 @@ The statistics endpoints (`GET /api/v1/agents/{agent_id}/stats`) expose per-agen
 - Active users
 - Token usage (prompt, completion, and total tokens)
 - Average response time and first-token latency (P50/P95)
-- Execution health (completed/failed/stopped outcomes and success rate)
+- Execution health — terminal run outcomes (completed, failed, stopped, and interrupted for worker loss), plus a success rate over terminal runs and a count of any runs whose status this build does not recognise
 - User interventions (steering, stopping, follow-ups)
 - Tool call count and tool usage (`GET /api/v1/agents/{agent_id}/stats/tool-usage`)
 - Usage trends (`GET /api/v1/agents/{agent_id}/stats/trends`)

--- a/docs/guide/admin-guide/agents/agent-management.md
+++ b/docs/guide/admin-guide/agents/agent-management.md
@@ -184,14 +184,15 @@ The statistics endpoints (`GET /api/v1/agents/{agent_id}/stats`) expose per-agen
 - Total conversations and messages
 - Active users
 - Token usage (prompt, completion, and total tokens)
-- Average response time
+- Average response time and first-token latency (P50/P95)
+- Execution health (completed/failed/stopped outcomes and success rate)
+- User interventions (steering, stopping, follow-ups)
 - Tool call count and tool usage (`GET /api/v1/agents/{agent_id}/stats/tool-usage`)
 - Usage trends (`GET /api/v1/agents/{agent_id}/stats/trends`)
-- Recent conversations (`GET /api/v1/agents/{agent_id}/stats/recent-conversations`)
 
 The admin list/detail actions expose these metrics; there is no separate **Statistics** tab.
 
-> **Note:** Not implemented / Roadmap: per-agent cost breakdowns, response-time percentiles (p50/p95/p99), export of statistics (CSV/PDF), and scheduled usage reports are not available. The statistics API returns the metrics listed above only.
+> **Note:** Not implemented / Roadmap: per-agent cost breakdowns, request-level response-time percentiles (p50/p95/p99) beyond first-token latency, export of statistics (CSV/PDF), and scheduled usage reports are not available. The statistics API returns the metrics listed above only.
 
 ## Knowledge Base Management
 

--- a/docs/guide/api-reference/endpoints/agents.md
+++ b/docs/guide/api-reference/endpoints/agents.md
@@ -778,17 +778,37 @@ curl -X GET "https://your-domain.com/api/v1/agents/550e8400-e29b-41d4-a716-44665
       "total_tokens": 456789
     },
     "performance": {
-      "avg_response_time_ms": 2300
+      "avg_response_time_ms": 2300,
+      "first_token_ms": {
+        "p50": 1200,
+        "p95": 9000,
+        "avg": 2500,
+        "samples": 480
+      }
     },
     "tools": {
       "tool_call_count": 512
+    },
+    "health": {
+      "completed": 90,
+      "failed": 6,
+      "stopped": 4,
+      "in_flight": 2,
+      "total": 100,
+      "success_rate": 0.9
+    },
+    "interventions": {
+      "steer": 12,
+      "stop": 3,
+      "follow_up": 5,
+      "total": 20
     }
   },
   "msg": "success"
 }
 ```
 
-Additional stats endpoints exist at `GET /agents/{agent_id}/stats/trends` (period `24h`/`7d`/`30d`), `GET /agents/{agent_id}/stats/tool-usage` (period `24h`/`7d`/`30d`/`all`), and `GET /agents/{agent_id}/stats/recent-conversations` (limit, default 10).
+Additional stats endpoints exist at `GET /agents/{agent_id}/stats/trends` (period `24h`/`7d`/`30d`) and `GET /agents/{agent_id}/stats/tool-usage` (period `24h`/`7d`/`30d`/`all`).
 
 ## Error Codes
 

--- a/docs/guide/api-reference/endpoints/agents.md
+++ b/docs/guide/api-reference/endpoints/agents.md
@@ -793,9 +793,11 @@ curl -X GET "https://your-domain.com/api/v1/agents/550e8400-e29b-41d4-a716-44665
       "completed": 90,
       "failed": 6,
       "stopped": 4,
+      "interrupted": 3,
+      "unrecognised": 0,
       "in_flight": 2,
-      "total": 100,
-      "success_rate": 0.9
+      "total": 103,
+      "success_rate": 0.8738
     },
     "interventions": {
       "steer": 12,
@@ -808,7 +810,18 @@ curl -X GET "https://your-domain.com/api/v1/agents/550e8400-e29b-41d4-a716-44665
 }
 ```
 
-Additional stats endpoints exist at `GET /agents/{agent_id}/stats/trends` (period `24h`/`7d`/`30d`) and `GET /agents/{agent_id}/stats/tool-usage` (period `24h`/`7d`/`30d`/`all`).
+`health` counts this agent's runs by outcome:
+
+| Field | Meaning |
+|-------|---------|
+| `completed` / `failed` / `stopped` | Run reached that terminal state. |
+| `interrupted` | **Terminal.** The worker executing the run was lost (crash, restart, eviction), so the run never reached completion. Counts toward `total` and lowers `success_rate`. |
+| `unrecognised` | Terminal from the caller's perspective only in the sense that it is not counted anywhere else: the stored status is not one this build knows (typically a value written by a different release). Reported separately so enum drift is visible instead of being folded into a bucket or failing the request. |
+| `in_flight` | Non-terminal runs (`queued`, `running`, `stopping`, `completing`, `waiting`). Excluded from `total` and from `success_rate`. |
+| `total` | `completed + failed + stopped + interrupted`. |
+| `success_rate` | `completed / total`, or `0` when there are no terminal runs. |
+
+Additional stats endpoints exist at `GET /api/v1/agents/{agent_id}/stats/trends` (period `24h`/`7d`/`30d`) and `GET /api/v1/agents/{agent_id}/stats/tool-usage` (period `24h`/`7d`/`30d`/`all`).
 
 ## Error Codes
 

--- a/docs/plan/statistics-aggregation-indexes.md
+++ b/docs/plan/statistics-aggregation-indexes.md
@@ -28,17 +28,18 @@ table owner:
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_conversations_agent_created_user
     ON conversations (agent_id, created_at) INCLUDE (user_id);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_conversations_agent_updated_at
-    ON conversations (agent_id, updated_at DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_conversations_agent_user_updated_at
+    ON conversations (agent_id, user_id, updated_at DESC);
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_conversation_role_created_at
     ON messages (conversation_id, role, created_at);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_workflow_runs_workflow_created_at
-    ON workflow_runs (workflow_id, created_at);
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_workflow_runs_workflow_covering
-    ON workflow_runs (workflow_id) INCLUDE (status, total_duration_ms);
+-- ONE index serves both per-workflow helpers. `created_at` must be a key
+-- column, not just an INCLUDE payload: workflow_run_overview reads
+-- MAX(created_at), and an INCLUDE-only column cannot satisfy it (see below).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_workflow_runs_workflow_created_covering
+    ON workflow_runs (workflow_id, created_at)
+    INCLUDE (status, total_duration_ms);
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_runs_agent_updated_at
     ON agent_runs (agent_id, updated_at);
@@ -47,35 +48,49 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_runs_agent_updated_at
 | Index | Serves |
 |---|---|
 | `conversations (agent_id, created_at) INCLUDE (user_id)` | overview counts, distinct active users, trend buckets |
-| `conversations (agent_id, updated_at DESC)` | `GET /agents/{id}/stats/recent-conversations` |
+| `conversations (agent_id, user_id, updated_at DESC)` | `GET /agents/{agent_id}/conversations`, which filters on both `agent_id` and `user_id` and orders by `updated_at` |
 | `messages (conversation_id, role, created_at)` | per-role counts, token sums, tool-call aggregation, first-token percentiles |
-| `workflow_runs (workflow_id, created_at)` | per-workflow trends |
-| `workflow_runs (workflow_id) INCLUDE (status, total_duration_ms)` | per-workflow overview, global run stats |
+| `workflow_runs (workflow_id, created_at) INCLUDE (status, total_duration_ms)` | BOTH `workflow_run_overview` (needs `created_at` for `MAX`) and `workflow_trend_buckets` |
 | `agent_runs (agent_id, updated_at)` | execution health and user-intervention counts |
 
 `agent_run_inputs` already carries a `run_id` index, which covers the
 intervention join; it needs no additional index.
 
-## Why `INCLUDE` rather than plain composite indexes
+## Why `created_at` must be a key column
 
-Measured on PostgreSQL 17 against 200k synthetic rows (50 workflows, 4000 runs
-for the probed id), aggregating `count(*) FILTER (...)` plus
-`AVG(total_duration_ms)` for one workflow:
+`workflow_run_overview` (`stats_sql.py`) selects `MAX(created_at)` alongside
+`status` and `total_duration_ms`. A covering index that holds `created_at` only
+in the `INCLUDE` payload **cannot** produce an Index Only Scan, because
+`MAX()` needs the key ordering. An earlier revision of this runbook specified
+`(workflow_id) INCLUDE (status, total_duration_ms)`, which cannot serve that
+query.
 
-| Plan | Buffers | Execution |
-|---|---|---|
-| Seq Scan (no index) | 2470 | 6.05 ms |
-| Bitmap scan on `(workflow_id, status)` | 2476 | 8.69 ms |
-| Index Only Scan on `(workflow_id) INCLUDE (status, total_duration_ms)` | 28 | 0.28 ms |
+Measured on PostgreSQL 17 with 200k synthetic rows, 4000 belonging to the
+probed workflow (matching the query the endpoint actually issues — `COUNT(*)
+FILTER (…)` per status, `AVG(total_duration_ms)`, and `MAX(created_at)`):
 
-A plain `(workflow_id, status)` index was **slower than the sequential scan**:
-the aggregate also reads `total_duration_ms`, so every one of the 4000 matches
-required a heap fetch, and the bitmap machinery was pure overhead. Only when
-the index covers every referenced column does the planner choose an Index Only
-Scan and skip the heap entirely.
+| Index | Plan | Planner cost | Buffers | Heap fetches |
+|---|---|---|---|---|
+| `(workflow_id) INCLUDE (status, total_duration_ms)` | Bitmap Heap Scan + Bitmap Index Scan | 2312.68 | 69 (42 hit, 27 read) | 42 heap blocks |
+| `(workflow_id, created_at) INCLUDE (status, total_duration_ms)` | **Index Only Scan** | **236.15** | **33** | **0** |
 
-The same effect on the agent side, counting conversations and distinct users
-for one agent over 30 days across 200k rows:
+The merged index is read from the index alone; the `INCLUDE`-only variant is
+forced to fetch 42 heap blocks for the same 4000 rows. Wall-clock time on a
+fully cached table is close (0.43 ms vs 0.73 ms), but the buffer accounting and
+the planner's ~10x cost gap are the durable signal: the gap widens with the
+working set, and the heap fetch is the thing this index exists to remove.
+
+Merging also means one index serves both helpers — the separate
+`(workflow_id, created_at)` index would itself fail the overview query for want
+of `status` and `total_duration_ms`.
+
+### The `INCLUDE` payload is a hard contract
+
+A plain `(workflow_id, status)` composite index was measured **slower than the
+sequential scan** it replaced: the aggregate also reads `total_duration_ms`, so
+every one of the 4000 matches required a heap fetch and the bitmap machinery was
+pure overhead. Same effect on the agent side, counting conversations and
+distinct users for one agent over 30 days across 200k rows:
 
 | Plan | Buffers | Execution |
 |---|---|---|
@@ -88,9 +103,12 @@ payload — re-measure rather than assuming the index still covers the query.
 ## Operating notes
 
 - **One statement at a time.** `CONCURRENTLY` builds cannot be batched into a
-  single script that runs in a transaction.
-- **A failed build leaves an `INVALID` index.** Verify afterwards and drop any
-  invalid leftovers before retrying:
+  single script that runs in a transaction, and `VACUUM` / `ANALYZE` cannot run
+  inside a transaction block at all.
+- **A failed build leaves an `INVALID` index, and `IF NOT EXISTS` will then skip
+  it.** `CONCURRENTLY` can fail partway and leave the index present but
+  unusable; because the name now exists, replaying the statement is a no-op and
+  the broken index stays. Always check first, and `DROP` before retrying:
 
   ```sql
   SELECT c.relname
@@ -99,23 +117,64 @@ payload — re-measure rather than assuming the index still covers the query.
   WHERE NOT i.indisvalid;
   ```
 
-- **`IF NOT EXISTS` makes reruns safe**, so the sequence can be replayed.
-- Re-run `ANALYZE conversations; ANALYZE messages; ANALYZE workflow_runs;`
-  afterwards so the planner sees the new indexes.
+  ```sql
+  DROP INDEX CONCURRENTLY IF EXISTS idx_workflow_runs_workflow_created_covering;
+  -- then re-run the CREATE INDEX CONCURRENTLY statement
+  ```
+
+- **`VACUUM (ANALYZE)`, not just `ANALYZE`, on every table you indexed.**
+  `ANALYZE` refreshes the planner statistics that make an Index Only Scan
+  *eligible*; the visibility map that lets it *skip the heap* is only built by
+  `VACUUM`. Freshly created indexes on a table with no all-visible pages report
+  `Heap Fetches` roughly equal to the row count and gain little.
+
+  ```sql
+  VACUUM (ANALYZE) conversations;
+  VACUUM (ANALYZE) messages;
+  VACUUM (ANALYZE) workflow_runs;
+  VACUUM (ANALYZE) agent_runs;
+  ```
 
 ## Verification
 
-Confirm the planner actually uses them, rather than assuming:
+Confirm the planner actually uses them, rather than assuming. The statement must
+reference **every** column of the production query — an `EXPLAIN` that omits
+`AVG(total_duration_ms)` or `MAX(created_at)` will show an Index Only Scan that
+the real query cannot get:
 
 ```sql
 EXPLAIN (ANALYZE, BUFFERS)
-SELECT count(*) FILTER (WHERE status = 'success')
+SELECT COUNT(*)                                     AS total_runs,
+       COUNT(*) FILTER (WHERE status = 'success')   AS success_count,
+       COUNT(*) FILTER (WHERE status = 'failed')    AS failed_count,
+       COUNT(*) FILTER (WHERE status = 'timeout')   AS timeout_count,
+       AVG(total_duration_ms) FILTER (WHERE total_duration_ms IS NOT NULL)
+                                                    AS avg_duration_ms,
+       MAX(created_at)                              AS last_run_at
 FROM workflow_runs
 WHERE workflow_id = '<id>'::uuid;
 ```
 
-Expect an **Index Only Scan**, not merely a bitmap index scan: as measured
-above, a bitmap scan that still fetches heap rows can be slower than the
-sequential scan it replaced. If the planner keeps choosing a sequential scan,
-the table is small enough that it is genuinely the cheaper plan and no action
-is needed.
+Expect an **Index Only Scan** with `Heap Fetches: 0`, not a bitmap index scan.
+Note the expected node for this query is an Index Only Scan or, when the
+planner has no reason to prefer it, a sequential scan — a *bitmap* plan here
+means the index does not cover the query and something is missing from the
+`INCLUDE` list or the key columns.
+
+For the agent-side trend query, which is the other consumer of the merged index:
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT date_trunc('day', created_at AT TIME ZONE 'Asia/Shanghai') AS bucket,
+       COUNT(*)                                    AS runs,
+       COUNT(*) FILTER (WHERE status = 'success')  AS success,
+       AVG(total_duration_ms)                      AS avg_duration
+FROM workflow_runs
+WHERE workflow_id = '<id>'::uuid
+  AND created_at >= now() - interval '30 days'
+GROUP BY bucket;
+```
+
+If the planner keeps choosing a sequential scan on a small table, that is
+genuinely the cheaper plan and no action is needed; the indexes exist for the
+tables that grow.

--- a/docs/plan/statistics-aggregation-indexes.md
+++ b/docs/plan/statistics-aggregation-indexes.md
@@ -34,9 +34,10 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_conversations_agent_user_updated_at
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_conversation_role_created_at
     ON messages (conversation_id, role, created_at);
 
--- ONE index serves both per-workflow helpers. `created_at` must be a key
--- column, not just an INCLUDE payload: workflow_run_overview reads
--- MAX(created_at), and an INCLUDE-only column cannot satisfy it (see below).
+-- ONE index serves both per-workflow helpers. `created_at` is a KEY, not an
+-- INCLUDE payload: workflow_trend_buckets filters on it, and a non-key column
+-- cannot be used as an index scan search qualification. (Its MAX(created_at)
+-- use by workflow_run_overview would work from INCLUDE alone — see below.)
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_workflow_runs_workflow_created_covering
     ON workflow_runs (workflow_id, created_at)
     INCLUDE (status, total_duration_ms);
@@ -50,55 +51,71 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_runs_agent_updated_at
 | `conversations (agent_id, created_at) INCLUDE (user_id)` | overview counts, distinct active users, trend buckets |
 | `conversations (agent_id, user_id, updated_at DESC)` | `GET /agents/{agent_id}/conversations`, which filters on both `agent_id` and `user_id` and orders by `updated_at` |
 | `messages (conversation_id, role, created_at)` | per-role counts, token sums, tool-call aggregation, first-token percentiles |
-| `workflow_runs (workflow_id, created_at) INCLUDE (status, total_duration_ms)` | BOTH `workflow_run_overview` (needs `created_at` for `MAX`) and `workflow_trend_buckets` |
+| `workflow_runs (workflow_id, created_at) INCLUDE (status, total_duration_ms)` | BOTH `workflow_run_overview` and `workflow_trend_buckets`; `created_at` is a key so the trend range predicate prunes |
 | `agent_runs (agent_id, updated_at)` | execution health and user-intervention counts |
 
 `agent_run_inputs` already carries a `run_id` index, which covers the
 intervention join; it needs no additional index.
 
-## Why `created_at` must be a key column
+## Why `created_at` is a key column, not an `INCLUDE` column
 
-`workflow_run_overview` (`stats_sql.py`) selects `MAX(created_at)` alongside
-`status` and `total_duration_ms`. A covering index that holds `created_at` only
-in the `INCLUDE` payload **cannot** produce an Index Only Scan, because
-`MAX()` needs the key ordering. An earlier revision of this runbook specified
-`(workflow_id) INCLUDE (status, total_duration_ms)`, which cannot serve that
-query.
+Two helpers share this index, and they need `created_at` for different reasons:
 
-Measured on PostgreSQL 17 with 200k synthetic rows, 4000 belonging to the
-probed workflow (matching the query the endpoint actually issues — `COUNT(*)
-FILTER (…)` per status, `AVG(total_duration_ms)`, and `MAX(created_at)`):
+- `workflow_run_overview` reads it for `MAX(created_at)`, an ordinary
+  aggregate over the scanned rows.
+- `workflow_trend_buckets` filters on it: `created_at >= $2`.
 
-| Index | Plan | Planner cost | Buffers | Heap fetches |
+A column in the `INCLUDE` payload is available to an Index Only Scan even
+though it is not a key (that is the point of `INCLUDE`), so an INCLUDE-only
+index *does* cover the overview query. What it cannot do is act as a **search
+qualification** — PostgreSQL documents that "a non-key column cannot be used in
+an index scan search qualification". So with `(workflow_id) INCLUDE
+(created_at, …)` the trend query must walk every index entry for the workflow
+and filter, while the same column as a key prunes the scan to the window.
+
+Measured on PostgreSQL 17, 200k rows with 9600 belonging to the probed workflow
+spread over 400 days (167 rows inside the 7-day window), `VACUUM (ANALYZE)`
+between runs:
+
+| Index | Query | Plan | Planner cost | Buffers |
 |---|---|---|---|---|
-| `(workflow_id) INCLUDE (status, total_duration_ms)` | Bitmap Heap Scan + Bitmap Index Scan | 2312.68 | 69 (42 hit, 27 read) | 42 heap blocks |
-| `(workflow_id, created_at) INCLUDE (status, total_duration_ms)` | **Index Only Scan** | **236.15** | **33** | **0** |
+| `(workflow_id) INCLUDE (created_at, status, total_duration_ms)` | overview | Index Only Scan | 539.35 | 73 |
+| `(workflow_id, created_at) INCLUDE (status, total_duration_ms)` | overview | Index Only Scan | 537.89 | 73 |
+| `(workflow_id) INCLUDE (created_at, status, total_duration_ms)` | trend | Index Only Scan, `Index Cond` on `workflow_id` only | 522.94 | 73 |
+| `(workflow_id, created_at) INCLUDE (status, total_duration_ms)` | trend | Index Only Scan, `Index Cond` on `workflow_id` **and** `created_at` | **33.61** | **5** |
 
-The merged index is read from the index alone; the `INCLUDE`-only variant is
-forced to fetch 42 heap blocks for the same 4000 rows. Wall-clock time on a
-fully cached table is close (0.43 ms vs 0.73 ms), but the buffer accounting and
-the planner's ~10x cost gap are the durable signal: the gap widens with the
-working set, and the heap fetch is the thing this index exists to remove.
-
-Merging also means one index serves both helpers — the separate
-`(workflow_id, created_at)` index would itself fail the overview query for want
-of `status` and `total_duration_ms`.
+Both cover the overview query equally — `MAX()` does *not* require a key, and
+the earlier claim in this runbook that it does was wrong. The difference is the
+range predicate: as a key it becomes an `Index Cond` and reads 5 buffers
+instead of 73 (14x fewer), which is why one index serves both helpers well.
+Making `created_at` a key also means the two per-workflow helpers do not need
+separate indexes.
 
 ### The `INCLUDE` payload is a hard contract
 
-A plain `(workflow_id, status)` composite index was measured **slower than the
-sequential scan** it replaced: the aggregate also reads `total_duration_ms`, so
-every one of the 4000 matches required a heap fetch and the bitmap machinery was
-pure overhead. Same effect on the agent side, counting conversations and
-distinct users for one agent over 30 days across 200k rows:
+Coverage depends on every referenced column being present, as either a key or
+an `INCLUDE` entry. An index that is missing one is not covering, and the
+planner falls back to fetching the heap:
+
+| Index | Query | Plan | Planner cost | Heap fetches |
+|---|---|---|---|---|
+| `(workflow_id) INCLUDE (status, total_duration_ms)` — `created_at` absent entirely | overview | Bitmap Heap Scan + Bitmap Index Scan | 2312.68 | 42 blocks |
+| `(workflow_id, created_at) INCLUDE (status, total_duration_ms)` | overview | Index Only Scan | 236.15 | 0 |
+
+Note the first row is *not* a counterexample to `INCLUDE` coverage: that index
+omits `created_at` from the index altogether, so it is simply not covering.
+A plain `(workflow_id, status)` composite behaves the same way — the aggregate
+also reads `total_duration_ms`, so every match needed a heap fetch and the
+bitmap machinery was pure overhead. Same effect on the agent side, counting
+conversations and distinct users for one agent over 30 days across 200k rows:
 
 | Plan | Buffers | Execution |
 |---|---|---|
 | Parallel Seq Scan | 2329 | 6.02 ms |
 | `(agent_id, created_at) INCLUDE (user_id)` | 503 | 0.64 ms |
 
-Any future change to the aggregation column list invalidates the `INCLUDE`
-payload — re-measure rather than assuming the index still covers the query.
+Any future change to the aggregation column list invalidates the index —
+re-measure rather than assuming it still covers the query.
 
 ## Operating notes
 

--- a/frontend/app/(platform)/app/apps/[id]/monitor/page.test.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/monitor/page.test.tsx
@@ -17,6 +17,8 @@ const statsFixture = () => ({
     completed: 67,
     failed: 2,
     stopped: 7,
+    interrupted: 0,
+    unrecognised: 0,
     in_flight: 2,
     total: 76,
     success_rate: 67 / 76,
@@ -189,13 +191,14 @@ test("reports execution health with a success rate over terminal runs", async ()
   expect(output).toContain('health.inFlight({"count":2})');
 });
 
-test("shows all three terminal health counts even when one is zero", async () => {
+test("drops a zero-count outcome from the donut while still counting it", async () => {
   getStats.mockImplementation(() => Promise.resolve({
     ...statsFixture(),
     health: {
       completed: 5,
       failed: 0,
       stopped: 2,
+      interrupted: 0,
       in_flight: 0,
       total: 7,
       success_rate: 5 / 7,
@@ -206,8 +209,120 @@ test("shows all three terminal health counts even when one is zero", async () =>
   const output = textOf(view.root);
 
   expect(output).toContain("71.4%");
-  // A zero-value slice drops out of the donut but stays in the legend totals.
   expect(output).toContain("health.stopped");
+  // `failed` is zero: it has no slice and therefore no legend row, even though
+  // it is still part of the terminal-run denominator above.
+  expect(output).not.toContain("health.failed");
+});
+
+test("reports interrupted runs as a terminal outcome, not as in-flight", async () => {
+  // Worker loss is terminal: it must appear in the donut and dilute the rate
+  // rather than be disguised as a run still in progress.
+  getStats.mockImplementation(() => Promise.resolve({
+    ...statsFixture(),
+    health: {
+      completed: 9,
+      failed: 1,
+      stopped: 0,
+      interrupted: 4,
+      in_flight: 1,
+      total: 14,
+      success_rate: 9 / 14,
+    },
+  }));
+
+  const view = await render();
+  const output = textOf(view.root);
+
+  expect(output).toContain("health.interrupted");
+  expect(output).toContain("64.3%");
+  expect(output).toContain('health.inFlight({"count":1})');
+  // `nameKey="label"` is unique to the health donut; the intervention bars
+  // share `dataKey="value"`.
+  const slices = view.root.findByProps({ nameKey: "label" }).props.data as Array<{
+    key: string;
+    value: number;
+  }>;
+  expect(slices.map((slice) => slice.key)).toEqual([
+    "completed",
+    "failed",
+    "interrupted",
+  ]);
+  expect(slices.map((slice) => slice.value)).toEqual([9, 1, 4]);
+});
+
+test("folds tools beyond the top eight into an Other slice", async () => {
+  // The donut normalizes over the data it is handed, so a truncated top-N would
+  // overstate every slice's share; the remainder must be represented.
+  getToolUsage.mockImplementation(() => Promise.resolve({
+    tools: Array.from({ length: 11 }, (_, index) => ({
+      name: `tool_${index}`,
+      display_name: `Tool ${index}`,
+      count: 20 - index,
+    })),
+  }));
+
+  const view = await render();
+  const slices = view.root.findByProps({ nameKey: "display_name" }).props.data as Array<{
+    name: string;
+    count: number;
+  }>;
+
+  // Eight named tools plus one aggregate slice.
+  expect(slices).toHaveLength(9);
+  expect(slices[slices.length - 1].name).toBe("__other__");
+  // The three dropped tools (counts 12, 11, 10) are summed, not discarded.
+  expect(slices[slices.length - 1].count).toBe(33);
+  expect(textOf(view.root)).toContain("charts.otherTools");
+});
+
+test("keeps every tool as its own slice when there are eight or fewer", async () => {
+  getToolUsage.mockImplementation(() => Promise.resolve({
+    tools: Array.from({ length: 8 }, (_, index) => ({
+      name: `tool_${index}`,
+      display_name: `Tool ${index}`,
+      count: 8 - index,
+    })),
+  }));
+
+  const view = await render();
+  const slices = view.root.findByProps({ nameKey: "display_name" }).props.data as Array<{
+    name: string;
+  }>;
+
+  expect(slices).toHaveLength(8);
+  expect(slices.some((slice) => slice.name === "__other__")).toBe(false);
+});
+
+test("omits the intervention rate when there are no terminal runs", async () => {
+  // Inputs are counted by their own timestamp and runs by `updated_at`, so a
+  // period can record interventions while no run has finished. Printing
+  // "0.00 across 0 terminal runs" beside nonzero bars would be a lie.
+  getStats.mockImplementation(() => Promise.resolve({
+    ...statsFixture(),
+    health: {
+      completed: 0,
+      failed: 0,
+      stopped: 0,
+      interrupted: 0,
+      in_flight: 1,
+      total: 0,
+      success_rate: 0,
+    },
+    interventions: { steer: 2, stop: 1, follow_up: 0, total: 3 },
+  }));
+
+  const view = await render();
+  const rows = view.root.findByProps({ layout: "vertical" }).props.data as Array<{
+    key: string;
+  }>;
+
+  // The bars still render...
+  expect(rows.map((row) => row.key)).toEqual(["steer", "stop"]);
+  // ...but the meaningless ratio does not.
+  const output = textOf(view.root);
+  expect(output).not.toContain("interventions.rate");
+  expect(output).not.toContain("interventions.rateHint");
 });
 
 test("shows first-token percentiles plus the series behind them", async () => {

--- a/frontend/app/(platform)/app/apps/[id]/monitor/page.tsx
+++ b/frontend/app/(platform)/app/apps/[id]/monitor/page.tsx
@@ -185,6 +185,7 @@ export default function MonitorPage({ params }: MonitorPageProps) {
     completed: { label: t('health.completed'), color: CHART_COLOR_ORDER[0] },
     failed: { label: t('health.failed'), color: CHART_COLOR_ORDER[4] },
     stopped: { label: t('health.stopped'), color: CHART_COLOR_ORDER[3] },
+    interrupted: { label: t('health.interrupted'), color: CHART_COLOR_ORDER[2] },
   }), [t])
 
   const latencyChartConfig: ChartConfig = React.useMemo(() => ({
@@ -206,6 +207,7 @@ export default function MonitorPage({ params }: MonitorPageProps) {
       { key: 'completed', label: t('health.completed'), value: health.completed, fill: CHART_SURFACE_COLORS[0] },
       { key: 'failed', label: t('health.failed'), value: health.failed, fill: CHART_SURFACE_COLORS[4] },
       { key: 'stopped', label: t('health.stopped'), value: health.stopped, fill: CHART_SURFACE_COLORS[3] },
+      { key: 'interrupted', label: t('health.interrupted'), value: health.interrupted, fill: CHART_SURFACE_COLORS[2] },
     ].filter((slice) => slice.value > 0)
   }, [stats, t])
 
@@ -213,6 +215,8 @@ export default function MonitorPage({ params }: MonitorPageProps) {
     completed: 0,
     failed: 0,
     stopped: 0,
+    interrupted: 0,
+    unrecognised: 0,
     in_flight: 0,
     total: 0,
     success_rate: 0,
@@ -245,12 +249,23 @@ export default function MonitorPage({ params }: MonitorPageProps) {
   const interventionRate =
     health.total > 0 ? interventions.total / health.total : 0
 
-  // The API already returns tools ordered by count descending; cap the slices
-  // so the donut and its legend stay readable.
-  const topTools = React.useMemo(
-    () => (toolUsage?.tools ?? []).slice(0, 8),
-    [toolUsage]
-  )
+  // The API already returns tools ordered by count descending. The donut's
+  // arcs are normalized over the data it receives, so a truncated top-N would
+  // overstate each slice's share; the remainder is folded into an "Other"
+  // slice so the ring still sums to `total_calls`.
+  const TOOL_SLICE_LIMIT = 8
+  const otherLabel = t('charts.otherTools')
+  const topTools = React.useMemo(() => {
+    const tools = toolUsage?.tools ?? []
+    if (tools.length <= TOOL_SLICE_LIMIT) return tools
+    const head = tools.slice(0, TOOL_SLICE_LIMIT)
+    const remainder = tools
+      .slice(TOOL_SLICE_LIMIT)
+      .reduce((sum, tool) => sum + tool.count, 0)
+    return remainder > 0
+      ? [...head, { name: '__other__', display_name: otherLabel, count: remainder }]
+      : head
+  }, [toolUsage, otherLabel])
 
   // Unwrap params
   const [resolvedParams, setResolvedParams] = React.useState<{ id: string } | null>(null)
@@ -889,22 +904,27 @@ export default function MonitorPage({ params }: MonitorPageProps) {
                         </ChartContainer>
                         {/* Raw counts grow with traffic, so the rate is what
                             makes two periods comparable. It shares the health
-                            card's denominator, so both cards agree. */}
-                        <div className="border-t pt-3">
-                          <div className="flex items-baseline justify-between">
-                            <span className="text-xs text-muted-foreground">
-                              {t('interventions.rate')}
-                            </span>
-                            <span className="text-lg font-semibold tabular-nums">
-                              {interventionRate.toFixed(2)}
-                            </span>
+                            card's denominator, so both cards agree — and when
+                            that denominator is zero the ratio is meaningless,
+                            so the whole block is omitted rather than printing
+                            "0.00 across 0 terminal runs" next to nonzero bars. */}
+                        {health.total > 0 && (
+                          <div className="border-t pt-3">
+                            <div className="flex items-baseline justify-between">
+                              <span className="text-xs text-muted-foreground">
+                                {t('interventions.rate')}
+                              </span>
+                              <span className="text-lg font-semibold tabular-nums">
+                                {interventionRate.toFixed(2)}
+                              </span>
+                            </div>
+                            <p className="mt-0.5 text-[11px] text-muted-foreground">
+                              {t('interventions.rateHint', {
+                                runs: formatNumber(health.total),
+                              })}
+                            </p>
                           </div>
-                          <p className="mt-0.5 text-[11px] text-muted-foreground">
-                            {t('interventions.rateHint', {
-                              runs: formatNumber(health.total),
-                            })}
-                          </p>
-                        </div>
+                        )}
                       </div>
                     ) : (
                       <div className="h-[220px] flex items-center justify-center text-muted-foreground">

--- a/frontend/i18n/en/agents.json
+++ b/frontend/i18n/en/agents.json
@@ -546,7 +546,8 @@
         "messages": "Messages",
         "tokens": "Tokens",
         "avgResponseTime": "Avg Response Time",
-        "calls": "Calls"
+        "calls": "Calls",
+        "otherTools": "Other tools"
       },
       "noToolUsage": "No tool usage data",
       "health": {
@@ -555,6 +556,7 @@
         "completed": "Completed",
         "failed": "Failed",
         "stopped": "Stopped",
+        "interrupted": "Interrupted",
         "successRate": "Success Rate",
         "empty": "No runs yet",
         "inFlight": "{count} in progress, excluded",

--- a/frontend/i18n/types/agents.ts
+++ b/frontend/i18n/types/agents.ts
@@ -1,4 +1,4 @@
-// GENERATED — 2026-09-12T10:00:34.357Z
+// GENERATED — 2026-09-12T12:17:43.839Z
 // Source: i18n/en/agents.json
 export type AgentsMessages = {
   agents: {
@@ -549,6 +549,7 @@ export type AgentsMessages = {
         tokens: string
         avgResponseTime: string
         calls: string
+        otherTools: string
       }
       noToolUsage: string
       health: {
@@ -557,6 +558,7 @@ export type AgentsMessages = {
         completed: string
         failed: string
         stopped: string
+        interrupted: string
         successRate: string
         empty: string
         inFlight: string

--- a/frontend/i18n/zh/agents.json
+++ b/frontend/i18n/zh/agents.json
@@ -546,7 +546,8 @@
         "messages": "消息数",
         "tokens": "Token",
         "avgResponseTime": "平均响应时间",
-        "calls": "调用次数"
+        "calls": "调用次数",
+        "otherTools": "其他工具"
       },
       "noToolUsage": "暂无工具使用数据",
       "health": {
@@ -555,6 +556,7 @@
         "completed": "成功",
         "failed": "失败",
         "stopped": "停止",
+        "interrupted": "中断",
         "successRate": "成功率",
         "empty": "暂无运行记录",
         "inFlight": "另有 {count} 个进行中，未计入",

--- a/frontend/lib/api/agents.test.ts
+++ b/frontend/lib/api/agents.test.ts
@@ -122,14 +122,12 @@ describe('agent stats API requests', () => {
     await agentStatsApi.getStats('agent-1')
     await agentStatsApi.getTrends('agent-1', '30d')
     await agentStatsApi.getToolUsage('agent-1')
-    await agentStatsApi.getRecentConversations('agent-1')
-    await agentStatsApi.getRecentConversations('agent-1', 25)
+    await agentStatsApi.getToolUsage('agent-1', '30d')
 
     expect(get).toHaveBeenNthCalledWith(1, '/agents/agent-1/stats?period=7d')
     expect(get).toHaveBeenNthCalledWith(2, '/agents/agent-1/stats/trends?period=30d')
     expect(get).toHaveBeenNthCalledWith(3, '/agents/agent-1/stats/tool-usage?period=7d')
-    expect(get).toHaveBeenNthCalledWith(4, '/agents/agent-1/stats/recent-conversations?limit=10')
-    expect(get).toHaveBeenNthCalledWith(5, '/agents/agent-1/stats/recent-conversations?limit=25')
+    expect(get).toHaveBeenNthCalledWith(4, '/agents/agent-1/stats/tool-usage?period=30d')
   })
 })
 

--- a/frontend/lib/api/agents.ts
+++ b/frontend/lib/api/agents.ts
@@ -1111,9 +1111,19 @@ export interface AgentRunHealth {
   completed: number
   failed: number
   stopped: number
-  /** Runs still queued/running/stopping; excluded from `total` and the rate. */
+  /** Worker-loss crashes; terminal, so they count toward `total`. */
+  interrupted: number
+  /**
+   * Runs whose status this build does not recognise (a value written by
+   * another release). Counted separately rather than folded into a bucket.
+   */
+  unrecognised: number
+  /**
+   * Non-terminal runs only (queued, running, stopping, completing, waiting);
+   * excluded from `total` and the rate.
+   */
   in_flight: number
-  /** Terminal runs only (completed + failed + stopped). */
+  /** Terminal runs only (completed + failed + stopped + interrupted). */
   total: number
   /** completed / total, or 0 when there are no terminal runs. */
   success_rate: number
@@ -1174,16 +1184,6 @@ export interface AgentToolUsage {
   total_calls: number
 }
 
-export interface RecentConversationItem {
-  id: string
-  title?: string | null
-  user?: { id: string; username: string } | null
-  message_count: number
-  token_usage: number
-  created_at: string
-  updated_at: string
-}
-
 // ============ Agent Stats API ============
 
 export const agentStatsApi = {
@@ -1206,13 +1206,6 @@ export const agentStatsApi = {
    */
   getToolUsage: async (agentId: string, period: string = '7d'): Promise<AgentToolUsage> => {
     return api.get<AgentToolUsage>(`/agents/${agentId}/stats/tool-usage?period=${period}`)
-  },
-
-  /**
-   * 获取最近对话
-   */
-  getRecentConversations: async (agentId: string, limit: number = 10): Promise<RecentConversationItem[]> => {
-    return api.get<RecentConversationItem[]>(`/agents/${agentId}/stats/recent-conversations?limit=${limit}`)
   },
 }
 

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -129,7 +129,6 @@ export {
   type AgentTrends,
   type AgentToolUsage,
   type ToolUsageItem,
-  type RecentConversationItem,
   type PublicAgent,
   type AgentRunStatus,
   type AgentRunMode,


### PR DESCRIPTION
Follow-up to #439, which merged the reviewed revision of the statistics aggregation work. A review of that revision found three blockers and two real defects; this PR is the fix set. `main` at the merge commit is byte-identical to the reviewed head, so the diff below is exactly these fixes.

Targets `main` directly (fresh branch), rather than the original feature branch, so no commit that is already squashed into `main` reappears in the history.

## Blockers

**The IDOR fix on `GET /workflows/runs` was undefended.** The endpoint passes its visibility scope positionally, and the test stub recorded only kwargs, so the filter never appeared in `workflow_query.filters`. Proof by mutation: deleting the two lines that apply the scope left the entire workflow suite green, including the dedicated access-guard test. The stub now records `*args`, and new tests assert the concrete `Q` branches reach the queryset. Removing the guard now fails 3 tests.

**The index runbook could not deliver its own Index Only Scan.** `(workflow_id) INCLUDE (status, total_duration_ms)` omits `created_at`, which `workflow_run_overview` reads via `MAX(created_at)`, and the runbook's verification `EXPLAIN` omitted `AVG(total_duration_ms)` and `MAX(created_at)` — so it would have falsely confirmed success. Measured on PostgreSQL 17, 200k rows / 4000 for the probed workflow, on the real production query:

| Index | Plan | Cost | Buffers | Heap fetches |
|---|---|---|---|---|
| `(workflow_id) INCLUDE (status, total_duration_ms)` | Bitmap Heap Scan | 2312.68 | 69 | 42 blocks |
| `(workflow_id, created_at) INCLUDE (status, total_duration_ms)` | Index Only Scan | 236.15 | 33 | 0 |

Merging also yields one index serving both per-workflow helpers. Also documented: `ANALYZE` alone does not build the visibility map an Index Only Scan needs (`VACUUM (ANALYZE)` does); a failed `CONCURRENTLY` build leaves an INVALID index that `IF NOT EXISTS` then skips; and `conversations (agent_id, updated_at)` had lost its consumer.

**`GET /agents/{id}/stats/recent-conversations` leaked across users and had no consumer.** It guarded with `check_agent_access` — satisfied by bare team membership for a TEAM agent — then filtered only by `agent_id`, returning every user's conversation titles, owner usernames and `token_usage`, unlike `GET /agents/{id}/conversations`, which scopes to `user=current_user`. The card that consumed it was removed with the monitor rework, so the only remaining caller was its own test. The route, the `RecentConversationItem` type, the client and their tests are deleted rather than widening a read nothing needs.

## Correctness

**`interrupted` runs were counted as in-flight.** `TERMINAL_AGENT_RUN_STATUSES` omitted `INTERRUPTED`, so a worker-loss crash was reported as "in progress" and excluded from the success-rate denominator — while the persistence layer stamps `finished_at` for it, `enqueue_input` refuses it as already-finished, and both `chat._wait_for_agent_run` and `run_agent_round` list it with the terminal set. It is now terminal, reported as its own `interrupted` count and charted as a slice. Because `mark_expired_runs_interrupted` had no caller, the status was never actually produced: a Celery task now sweeps every two minutes (the run lease is 60s), so crashes stop being misreported.

**The 24h trend window did not match its point grid.** At 12:37 the window started at 12:37 while the first rendered hourly point was 13:00, so rows in the leading partial bucket were fetched, bucketed to a key that is never rendered and silently discarded. The window is now derived from the first rendered point, which fixes 7d/30d too. Verified against live data: the old 7d window dropped 1 conversation / 5 messages, and bucket sums now reconcile with the window total (30d: 45 conversations / 154 messages, matching the overview exactly).

## Also

- `check_workflow_access(require_write=True)` handed a non-owner team admin any PRIVATE workflow. The model documents PRIVATE as "Only creator can access" and `workflow_read_visibility_filter` hides those rows from the list and stats endpoints, so the write path contradicted both — an id-guessing IDOR reachable by an admin. Non-owner writes are now refused, mirroring `check_agent_access`; the creator-less legacy branch keeps team scope. **This is a behaviour change**: an admin who previously relied on it now gets 403.
- An unrecognised run status raised `ValueError`, turning a statistics read into a 500 on enum drift; it is counted as `unrecognised` instead — visible, not folded into a bucket.
- Bounded the aggregate fan-out with a shared semaphore (`DB_AGGREGATE_CONCURRENCY`) instead of five simultaneous pool checkouts against a pool of five. Raising the pool was not an option: `max_connections` is 100 and the default deployment already runs ~17 processes x pool.
- Monitor: the tool donut normalized over a silently truncated top 8, overstating each slice; the remainder is now an "Other" slice so the ring sums to `total_calls`. The intervention rate no longer prints "0.00 across 0 terminal runs" beside nonzero bars.
- Removed dead test stubs left by the pushdown, pinned exact period windows (swapping 24h for 7d used to stay green), and pinned the MCP no-network guarantee on `McpClient.list_tools` rather than the wrapper — that method has no timeout.

## Verification

- Backend: 7154 passed, 3 skipped; coverage gate 96.84% line / 95.01% branch (required 95).
- Frontend: 2454 passed; coverage gate 95.04% functions / 97.60% lines.
- `ruff check` + `ruff format --check` clean, `tsc --noEmit` clean, `i18n:lint` and the key-usage check pass (en/zh/generated types in lockstep).
- All 14 statistics helpers executed against live PostgreSQL 17 (20 queries, 0 failures); per-role ground truth matched exactly.
- Guard removal and status-set changes were mutation-tested, not just reviewed.

## Rollout notes

- The worker-loss sweep is new scheduled work; it scans `agent_runs` for `running`/`stopping` every two minutes. Fine at current volume; worth a `status` index if the table grows.
- The index runbook remains an ops step (not a startup migration) and its `VACUUM (ANALYZE)` requirement is now documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lost agent runs are automatically marked as interrupted and included in execution health statistics.
  - Agent monitoring now shows interrupted and unrecognised outcomes, groups tools beyond the top eight under “Other,” and hides intervention rates when no terminal runs exist.
  - Private workflow access now consistently enforces creator and team-admin permissions.

- **Bug Fixes**
  - Improved statistics trend windows and aggregate-query reliability.

- **Removed**
  - Removed the recent-conversations statistics endpoint and related API support.

- **Documentation**
  - Updated agent statistics and monitoring documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->