### PR TITLE
fix(chat): fix chat container scrolling when headerInset is false

### DIFF
--- a/backend/tests/services/test_usage_tracker_issue255.py
+++ b/backend/tests/services/test_usage_tracker_issue255.py
@@ -10,7 +10,12 @@ from app.services.usage_tracker import QuotaExceededError, UsageTracker
 
 
 usage_module = import_module("app.services.usage_tracker")
-NOW = datetime.now(timezone.utc)
+NOW = datetime(2026, 7, 19, 12, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def freeze_usage_time(monkeypatch):
+    monkeypatch.setattr(usage_module, "now", lambda: NOW)
 
 
 def team_model(**overrides):

--- a/frontend/components/chat/chat-container.test.tsx
+++ b/frontend/components/chat/chat-container.test.tsx
@@ -85,6 +85,7 @@ describe('ChatContainer', () => {
     const messages = [textMessage('u1', 'user', 'hello')]
     const html = renderContainer(<ChatContainer messages={messages} />)
     expect(html).toContain('absolute inset-x-0 bottom-0 overflow-y-auto')
+    expect(html).toContain('top-0')
     expect(html).not.toContain('top-[60px]')
   })
 

--- a/frontend/components/chat/chat-container.tsx
+++ b/frontend/components/chat/chat-container.tsx
@@ -568,7 +568,7 @@ export function ChatContainer({
     <div className={cn('relative h-full', className)}>
       <div
         ref={scrollerRef}
-        className={cn('absolute inset-x-0 bottom-0 overflow-y-auto overflow-x-hidden [overflow-anchor:none] [scrollbar-gutter:stable]', headerInset && 'top-[60px]')}
+        className={cn('absolute inset-x-0 bottom-0 overflow-y-auto overflow-x-hidden [overflow-anchor:none] [scrollbar-gutter:stable]', headerInset ? 'top-[60px]' : 'top-0')}
         onScroll={handleScroll}
       >
         <div ref={contentRef}>


### PR DESCRIPTION
## Summary
Fix an issue where chat message history in the Agent orchestration and preview panel cannot scroll.

### Problem
The scroller container in `ChatContainer` used `absolute inset-x-0 bottom-0` with conditional `headerInset && 'top-[60px]'`. When `headerInset` was `false` (default on agent orchestration/preview surfaces), the lack of `top-0` left the element's height unconstrained (`height: auto`), causing `scrollHeight === clientHeight` and preventing scrolling.

### Changes
- Updated the positioning classes of the scroller in `frontend/components/chat/chat-container.tsx` to `headerInset ? 'top-[60px]' : 'top-0'`.
- Added assertion in `frontend/components/chat/chat-container.test.tsx` ensuring `top-0` is present when `headerInset` is not provided.

### Verification
- Ran full frontend test suite: 2454 tests passed.
- Pre-commit linters and i18n checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the chat scroller consistently uses the correct top offset when a header inset is enabled.
  * Confirmed the chat scroller spans the full viewport when no header inset is provided.

* **Tests**
  * Improved time-dependent usage tracking tests for consistent, repeatable results.
  * Added coverage for the chat scroller’s top positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->